### PR TITLE
Various fixes

### DIFF
--- a/Common/PlayerCommon/CollisionPlayer.cs
+++ b/Common/PlayerCommon/CollisionPlayer.cs
@@ -11,7 +11,7 @@ internal class CollisionPlayer : ModPlayer
 	public bool FallThrough()
 	{
 		_noReset = true;
-		return fallThrough;
+		return fallThrough || Player.grapCount > 0;
 	}
 
 	public override void ResetEffects()

--- a/Common/TileCommon/Corruption/TileCorruptionGlobalTile.cs
+++ b/Common/TileCommon/Corruption/TileCorruptionGlobalTile.cs
@@ -10,6 +10,9 @@ internal class TileCorruptionGlobalTile : GlobalTile
 	/// </summary>
 	public override bool TileFrame(int i, int j, int type, ref bool resetFrame, ref bool noBreak)
 	{
+		if (!ConversionHandler.ConversionTypes.Contains(type))
+			return true; //Only run for registered conversion types
+
 		int x = i;
 		int y = j;
 

--- a/Common/TileCommon/PresetTiles/Furniture/ChestTile.cs
+++ b/Common/TileCommon/PresetTiles/Furniture/ChestTile.cs
@@ -116,8 +116,8 @@ public abstract class ChestTile : FurnitureTile
 		}
 		else if (isLocked && KeyLookup.TryGetValue(Type, out int chestKey))
 		{
-			player.ConsumeItem(chestKey);
-			Chest.Unlock(i, j);
+			if (player.ConsumeItem(chestKey))
+				Chest.Unlock(i, j);
 		}
 		else
 		{

--- a/Common/TileCommon/TileExtensions.cs
+++ b/Common/TileCommon/TileExtensions.cs
@@ -103,6 +103,7 @@ public static class TileExtensions
 	{
 		var tile = Framing.GetTileSafely(i, j);
 		var data = TileObjectData.GetTileData(tile);
+
 		if (data is null)
 			return;
 

--- a/Common/WallCommon/IAutoloadUnsafeWall.cs
+++ b/Common/WallCommon/IAutoloadUnsafeWall.cs
@@ -52,4 +52,11 @@ public class UnsafeWallLoader : ModSystem
 internal static class AutoloadedWallExtensions
 {
 	public static int GetUnsafe(this IAutoloadUnsafeWall wall, Mod mod) => mod.Find<ModWall>(wall.Name + "Unsafe").Type;
+
+	/// <summary> Attempts to find the autoloaded unsafe wall associated with the given Type. Throws an exception on failure. </summary>
+	public static int UnsafeWallType<T>() where T : ModWall
+	{
+		var mod = SpiritReforgedMod.Instance;
+		return mod.Find<ModWall>(ModContent.GetInstance<T>().Name + "Unsafe").Type;
+	}
 }

--- a/Content/Desert/CactusStaff/CactusWallProj.cs
+++ b/Content/Desert/CactusStaff/CactusWallProj.cs
@@ -24,6 +24,7 @@ public class CactusWallProj : ModProjectile
 		Projectile.frame = Main.rand.Next(3);
 		Projectile.tileCollide = false;
 		Projectile.ignoreWater = true;
+		Projectile.hide = true; //Used in conjunction with DrawBehind
 
 		DrawOriginOffsetY = -30;
 	}
@@ -87,6 +88,9 @@ public class CactusWallProj : ModProjectile
 
 	public override void ModifyHitNPC(NPC target, ref NPC.HitModifiers modifiers)
 		=> modifiers.HitDirectionOverride = target.Center.X < Projectile.Center.X ? -1 : 1;
+
+	public override void DrawBehind(int index, List<int> behindNPCsAndTiles, List<int> behindNPCs, List<int> behindProjectiles, List<int> overPlayers, List<int> overWiresUI)
+		=> behindNPCsAndTiles.Add(index);
 
 	public override bool PreDraw(ref Color lightColor)
 	{

--- a/Content/Forest/FairyWhistle/FairyWhistle.cs
+++ b/Content/Forest/FairyWhistle/FairyWhistle.cs
@@ -1,8 +1,10 @@
+using SpiritReforged.Common.ModCompat.Classic;
 using Terraria.Audio;
 using Terraria.DataStructures;
 
 namespace SpiritReforged.Content.Forest.FairyWhistle;
 
+[FromClassic("FairyWhistleItem")]
 public class FairyWhistle : ModItem
 {
 	public override void SetDefaults()

--- a/Content/Forest/RoguesCrest/RogueKnifeMinion.cs
+++ b/Content/Forest/RoguesCrest/RogueKnifeMinion.cs
@@ -10,8 +10,6 @@ public class RogueKnifeMinion() : BaseMinion(500, 900, new Vector2(12, 12))
 {
 	private bool Trailing => Projectile.velocity.Length() >= ProjectileID.Sets.TrailCacheLength[Type] && AiState == Attacking;
 
-	private bool animate = false;
-
 	private const int Returning = 0;
 	private const int Attacking = 1;
 	private const int LockedToPlayer = 2;
@@ -47,10 +45,7 @@ public class RogueKnifeMinion() : BaseMinion(500, 900, new Vector2(12, 12))
 
 	public override void AI()
 	{
-		animate = false;
-
 		base.AI();
-
 		AiTimer = Math.Max(0, AiTimer - 1);
 	}
 
@@ -117,8 +112,6 @@ public class RogueKnifeMinion() : BaseMinion(500, 900, new Vector2(12, 12))
 					ParticleHandler.SpawnParticle(new Particles.ImpactLine(position, Projectile.velocity * .1f, color, scale, 8, Projectile));
 				}
 			}
-
-			animate = true;
 		}
 	}
 
@@ -141,8 +134,8 @@ public class RogueKnifeMinion() : BaseMinion(500, 900, new Vector2(12, 12))
 
 	public override bool DoAutoFrameUpdate(ref int framesPerSecond, ref int startFrame, ref int endFrame)
 	{
-		framesPerSecond = 22;
-		return animate;
+		framesPerSecond = 28;
+		return true;
 	}
 
 	public override bool PreDraw(ref Color lightColor)

--- a/Content/Ocean/Items/Reefhunter/Buffs/EmpoweredSwim.cs
+++ b/Content/Ocean/Items/Reefhunter/Buffs/EmpoweredSwim.cs
@@ -10,6 +10,7 @@ public class EmpoweredSwim : ModBuff
 		player.accFlipper = true;
 
 		if (player.buffTime[buffIndex] > 2)
+		{
 			if (player.wet && !Collision.SolidCollision(player.BottomLeft, player.width, 4))
 			{
 				player.fullRotationOrigin = player.Size / 2f;
@@ -17,6 +18,7 @@ public class EmpoweredSwim : ModBuff
 			}
 			else
 				player.fullRotation *= 0.8f;
+		}
 		else
 			player.fullRotation = 0f;
 	}

--- a/Content/Ocean/Items/Reefhunter/OceanPendant/OceanPendant.cs
+++ b/Content/Ocean/Items/Reefhunter/OceanPendant/OceanPendant.cs
@@ -40,7 +40,6 @@ public class OceanPendantLayer : PlayerDrawLayer
 
 	public override void Load() => glowTexture = ModContent.Request<Texture2D>(GetType().Namespace.Replace(".", "/") + "/OceanPendant_Neck_Glow");
 	public override Position GetDefaultPosition() => new AfterParent(PlayerDrawLayers.NeckAcc);
-	public override bool IsHeadLayer => false;
 
 	public override bool GetDefaultVisibility(PlayerDrawSet drawInfo)
 	{

--- a/Content/Savanna/Biome/SavannaBiome.cs
+++ b/Content/Savanna/Biome/SavannaBiome.cs
@@ -16,7 +16,7 @@ public class SavannaBiome : ModBiome
 
 	public override void SetStaticDefaults() => NPCHappinessHelper.SetAverage<SavannaBiome>(ModContent.GetInstance<JungleBiome>(), ModContent.GetInstance<DesertBiome>());
 
-	public override SceneEffectPriority Priority => SceneEffectPriority.Environment;
+	public override SceneEffectPriority Priority => SceneEffectPriority.BiomeMedium;
 	public override int Music => GetMusic();
 	public override ModWaterStyle WaterStyle => ModContent.GetInstance<SavannaWaterStyle>();
 	public override ModSurfaceBackgroundStyle SurfaceBackgroundStyle => ModContent.GetInstance<SavannaBGStyle>();

--- a/Content/Savanna/Ecotone/BaobabGen.cs
+++ b/Content/Savanna/Ecotone/BaobabGen.cs
@@ -1,4 +1,5 @@
-﻿using SpiritReforged.Common.WorldGeneration;
+﻿using SpiritReforged.Common.WallCommon;
+using SpiritReforged.Common.WorldGeneration;
 using SpiritReforged.Content.Savanna.Tiles;
 using SpiritReforged.Content.Savanna.Walls;
 using System.Linq;
@@ -36,8 +37,10 @@ internal static class BaobabGen
 		var opening = new Rectangle(x - openingSize.X / 2, y - openingSize.Y - 1, openingSize.X, openingSize.Y);
 		ShapeData data = new();
 
+		ushort baobabWall = (ushort)AutoloadedWallExtensions.UnsafeWallType<LivingBaobabWall>();
+
 		WorldUtils.Gen(new Point(x - width / 2, y - preCurveHeight), new Shapes.Rectangle(width, preCurveHeight), 
-			Actions.Chain(new Actions.SetTile((ushort)ModContent.TileType<LivingBaobab>()).Output(data), new Actions.PlaceWall((ushort)ModContent.WallType<LivingBaobabWall>()))); //Rectangle body
+			Actions.Chain(new Actions.SetTile((ushort)ModContent.TileType<LivingBaobab>()).Output(data), new Actions.PlaceWall(baobabWall))); //Rectangle body
 
 		WorldUtils.Gen(new Point(x - width / 2, y - preCurveHeight), new ModShapes.InnerOutline(data, false), Actions.Chain(new Modifiers.IsTouchingAir(), new Actions.ClearWall()));
 
@@ -46,7 +49,7 @@ internal static class BaobabGen
 
 		for (int i = 0; i < 2; i++) //Curved top
 			WorldUtils.Gen(new Point(x - 1 + i, y - preCurveHeight - 1), new Shapes.Mound(width / 2, curveHeight), Actions.Chain(new Actions.SetTile((ushort)ModContent.TileType<LivingBaobab>()), 
-				new Modifiers.Offset(0, 1), new Actions.PlaceWall((ushort)ModContent.WallType<LivingBaobabWall>()), new Modifiers.IsTouchingAir(), new Actions.ClearWall()));
+				new Modifiers.Offset(0, 1), new Actions.PlaceWall(baobabWall), new Modifiers.IsTouchingAir(), new Actions.ClearWall()));
 
 		WorldGen.PlaceTile(opening.Center.X - 1, opening.Bottom - 1, ModContent.TileType<BaobabPod>(), true);
 
@@ -83,8 +86,10 @@ internal static class BaobabGen
 			int halfWidth = WorldGen.genRand.Next(7, 13);
 			var last = points.Last().ToPoint();
 
+			ushort baobabLeafWall = (ushort)AutoloadedWallExtensions.UnsafeWallType<LivingBaobabLeafWall>();
+
 			WorldUtils.Gen(last, new Shapes.Mound(halfWidth, WorldGen.genRand.Next(4, 6)), Actions.Chain(new Modifiers.SkipTiles((ushort)ModContent.TileType<LivingBaobab>()), 
-				new Modifiers.Blotches(2, 0.1), new Actions.SetTile((ushort)ModContent.TileType<LivingBaobabLeaf>()).Output(data), new Actions.PlaceWall((ushort)ModContent.WallType<LivingBaobabLeafWall>()))); //Add a canopy
+				new Modifiers.Blotches(2, 0.1), new Actions.SetTile((ushort)ModContent.TileType<LivingBaobabLeaf>()).Output(data), new Actions.PlaceWall(baobabLeafWall))); //Add a canopy
 
 			WorldUtils.Gen(points.Last().ToPoint(), new ModShapes.InnerOutline(data, true), Actions.Chain(new Actions.ClearWall()));
 			WorldUtils.Gen(points.Last().ToPoint(), new ModShapes.InnerOutline(data, false), Actions.Chain(new Modifiers.Dither(), new Actions.Smooth()));

--- a/Content/Savanna/Ecotone/SavannaEcotone.cs
+++ b/Content/Savanna/Ecotone/SavannaEcotone.cs
@@ -1,4 +1,5 @@
 ﻿using SpiritReforged.Common.TileCommon.Tree;
+using SpiritReforged.Common.WallCommon;
 using SpiritReforged.Common.WorldGeneration;
 using SpiritReforged.Common.WorldGeneration.Ecotones;
 using SpiritReforged.Content.Savanna.Items;
@@ -168,7 +169,7 @@ internal class SavannaEcotone : EcotoneBase
 						else if (tile.TileType is TileID.Sandstone || TileID.Sets.Ore[tile.TileType])
 							tile.WallType = WallID.Sandstone;
 						else if (tile.WallType is WallID.None or WallID.DirtUnsafe)
-							tile.WallType = (ushort)ModContent.WallType<SavannaDirtWall>();
+							tile.WallType = (ushort)AutoloadedWallExtensions.UnsafeWallType<SavannaDirtWall>();
 					}
 					else
 						tile.Clear(TileDataType.Wall); //Clear walls above the Savanna surface

--- a/Content/Savanna/Items/CampfireSpit.cs
+++ b/Content/Savanna/Items/CampfireSpit.cs
@@ -209,7 +209,7 @@ public class RoastGlobalTile : GlobalTile
 
 	public override bool PreDraw(int i, int j, int type, SpriteBatch spriteBatch)
 	{
-		if (TileObjectData.IsTopLeft(i, j) && Entity(i, j) is CampfireSlot slot)
+		if (TileID.Sets.Campfire[type] && TileObjectData.IsTopLeft(i, j) && Entity(i, j) is CampfireSlot slot)
 		{
 			var position = new Vector2(i, j) * 16 + new Vector2(Main.offScreenRange) - Main.screenPosition - new Vector2(0, 16);
 			spriteBatch.Draw(TileTexture.Value, position, Lighting.GetColor(i + 1, j + 1));

--- a/Content/Savanna/Tiles/AcaciaTree/TreetopPlatform.cs
+++ b/Content/Savanna/Tiles/AcaciaTree/TreetopPlatform.cs
@@ -110,7 +110,9 @@ internal class AcaciaPlatformDetours : ILoadable
 
 		foreach (var p in AcaciaTree.Platforms)
 		{
-			if (self.getRect().Intersects(p.Hitbox) && !Collision.SolidCollision(self.Bottom, self.width, 8))
+			var hitbox = new Rectangle(p.Hitbox.X, p.Hitbox.Y + 18, p.Hitbox.Width, 1); //Adjust the hitbox to be more grapple friendly
+
+			if (self.getRect().Intersects(hitbox) && !Collision.SolidCollision(self.Bottom, self.width, 8))
 			{
 				var owner = Main.player[self.owner];
 

--- a/Content/Savanna/Walls/LivingBaobabLeafWall.cs
+++ b/Content/Savanna/Walls/LivingBaobabLeafWall.cs
@@ -8,7 +8,10 @@ public class LivingBaobabLeafWall : ModWall, IAutoloadUnsafeWall, IAutoloadWallI
 	{
 		Main.wallHouse[Type] = true;
 		DustType = DustID.WoodFurniture;
-		AddMapEntry(new Color(71, 79, 24));
+
+		var entryColor = new Color(71, 79, 24);
+		AddMapEntry(entryColor);
+		Mod.Find<ModWall>(Name + "Unsafe").AddMapEntry(entryColor); //Set the unsafe wall's map entry
 	}
 
 	public override void NumDust(int i, int j, bool fail, ref int num) => num = fail ? 1 : 3;

--- a/Content/Savanna/Walls/LivingBaobabWall.cs
+++ b/Content/Savanna/Walls/LivingBaobabWall.cs
@@ -8,7 +8,10 @@ public class LivingBaobabWall : ModWall, IAutoloadUnsafeWall, IAutoloadWallItem
 	{
 		Main.wallHouse[Type] = true;
 		DustType = DustID.WoodFurniture;
-		AddMapEntry(new Color(107, 70, 50));
+
+		var entryColor = new Color(107, 70, 50);
+		AddMapEntry(entryColor);
+		Mod.Find<ModWall>(Name + "Unsafe").AddMapEntry(entryColor); //Set the unsafe wall's map entry
 	}
 
 	public override void NumDust(int i, int j, bool fail, ref int num) => num = fail ? 1 : 3;

--- a/Content/Savanna/Walls/SavannaDirtWall.cs
+++ b/Content/Savanna/Walls/SavannaDirtWall.cs
@@ -19,7 +19,12 @@ public class SavannaDirtWall : ModWall, IAutoloadWallItem
 			.AddTile(TileID.WorkBenches)
 			.Register();
 	}
-	public override void SetStaticDefaults() => AddMapEntry(new Color(98, 39, 5));
+
+	public override void SetStaticDefaults()
+	{
+		Main.wallHouse[Type] = true;
+		AddMapEntry(new Color(98, 39, 5));
+	}
 
 	public override bool WallFrame(int i, int j, bool randomizeFrame, ref int style, ref int frameNumber)
 	{

--- a/Content/Savanna/Walls/SavannaDirtWall.cs
+++ b/Content/Savanna/Walls/SavannaDirtWall.cs
@@ -2,7 +2,7 @@ using SpiritReforged.Common.WallCommon;
 
 namespace SpiritReforged.Content.Savanna.Walls;
 
-public class SavannaDirtWall : ModWall, IAutoloadWallItem
+public class SavannaDirtWall : ModWall, IAutoloadUnsafeWall, IAutoloadWallItem
 {
 	public void AddItemRecipes(ModItem item)
 	{
@@ -23,7 +23,10 @@ public class SavannaDirtWall : ModWall, IAutoloadWallItem
 	public override void SetStaticDefaults()
 	{
 		Main.wallHouse[Type] = true;
-		AddMapEntry(new Color(98, 39, 5));
+
+		var entryColor = new Color(98, 39, 5);
+		AddMapEntry(entryColor);
+		Mod.Find<ModWall>(Name + "Unsafe").AddMapEntry(entryColor); //Set the unsafe wall's map entry
 	}
 
 	public override bool WallFrame(int i, int j, bool randomizeFrame, ref int style, ref int frameNumber)

--- a/Content/Underground/Zipline/ZiplineHandler.cs
+++ b/Content/Underground/Zipline/ZiplineHandler.cs
@@ -4,6 +4,7 @@ using SpiritReforged.Common.PlayerCommon;
 using SpiritReforged.Content.Particles;
 using System.Linq;
 using Terraria.Audio;
+using Terraria.DataStructures;
 using Terraria.ModLoader.IO;
 
 namespace SpiritReforged.Content.Underground.Zipline;
@@ -109,6 +110,9 @@ internal class ZiplinePlayer : ModPlayer
 			_wasOnZipline = false;
 		}
 	}
+
+	/// <summary> <inheritdoc/><para/> Resets rotation on death. </summary>
+	public override void Kill(double damage, int hitDirection, bool pvp, PlayerDeathReason damageSource) => Player.fullRotation = 0;
 
 	/// <summary> Zipline visuals and sounds associated with this player. </summary>
 	public void DoEffects(Vector2 start, Vector2 end)


### PR DESCRIPTION
- Reduced Savanna biome priority
- Made Cactus Staff projectiles draw behind tiles
- Made Rogue's Crest minion animate continuously
- Ensured the player's rotation is reset after death
- Made Fairy Whistle overwrite the Classic version
- Fixed Pirate Chest being unlockable without a key when Classic is enabled
- Improved Acacia Treetop grapple detection with the Squirrel Hook
- Made player-placed Coarse Dirt Walls safe
- Prevented custom tile corruption logic from running for unrelated tile types
- Fixed a drawing error with Stone Platforms