### PR TITLE
Misc fixes

### DIFF
--- a/Common/ModCompat/Classic/SpiritClassic.cs
+++ b/Common/ModCompat/Classic/SpiritClassic.cs
@@ -122,17 +122,6 @@ internal class SpiritClassic : ModSystem
 		return true;
 	}
 
-	/*public override void ModifyWorldGenTasks(List<GenPass> tasks, ref double totalWeight) //PreAddContent handles this more accurately
-	{
-		int memorial = tasks.FindIndex(x => x.Name == "A Hero's Memorial");
-		if (memorial != -1)
-			tasks[memorial].Disable();
-
-		int stargrass = tasks.FindIndex(x => x.Name == "Stargrass Micropass");
-		if (stargrass != -1)
-			tasks[stargrass].Disable();
-	}*/
-
 	public override void PostWorldGen()
 	{
 		foreach (var c in Main.chest)
@@ -154,6 +143,13 @@ internal class SpiritClassic : ModSystem
 			if (!item.IsAir && ClassicToReforged.TryGetValue(item.type, out int reforgedType))
 				item.ChangeItemType(reforgedType);
 		}
+	}
+
+	/// <summary> Manually adds a ModItem replacement entry to <see cref="ClassicToReforged"/>, if loaded. </summary>
+	public static void AddReplacement(string classicName, int reforgedType)
+	{
+		if (Enabled && ClassicMod.TryFind(classicName, out ModItem item))
+			ClassicToReforged.Add(item.Type, reforgedType);
 	}
 }
 

--- a/Common/ModCompat/FablesCompat.cs
+++ b/Common/ModCompat/FablesCompat.cs
@@ -1,20 +1,4 @@
-﻿using SpiritReforged.Common.ItemCommon.Backpacks;
-using SpiritReforged.Common.WorldGeneration.Micropasses.Passes;
-using SpiritReforged.Common.WorldGeneration.PointOfInterest;
-using SpiritReforged.Content.Forest.Backpacks;
-using SpiritReforged.Content.Forest.Botanist.Items;
-using SpiritReforged.Content.Forest.Botanist.Tiles;
-using SpiritReforged.Content.Forest.Stargrass.Tiles;
-using SpiritReforged.Content.Ocean.Items.KoiTotem;
-using SpiritReforged.Content.Ocean.Items.Reefhunter.OceanPendant;
-using SpiritReforged.Content.Ocean.Items.Vanity.DiverSet;
-using SpiritReforged.Content.Savanna.Items.HuntingRifle;
-using SpiritReforged.Content.Savanna.Items.Vanity;
-using SpiritReforged.Content.Savanna.Tiles;
-using Terraria.DataStructures;
-using Terraria.WorldBuilding;
-
-namespace SpiritReforged.Common.ModCompat;
+﻿namespace SpiritReforged.Common.ModCompat;
 
 internal class FablesCompat : ModSystem
 {

--- a/Common/TileCommon/PresetTiles/SingleSlotEntity.cs
+++ b/Common/TileCommon/PresetTiles/SingleSlotEntity.cs
@@ -15,7 +15,6 @@ public abstract class SingleSlotEntity : ModTileEntity
 	/// <returns> Whether an interaction has occured. </returns>
 	public virtual bool OnInteract(Player player)
 	{
-		var lastItem = item;
 		bool success = CanAddItem(player.HeldItem);
 
 		if (!item.IsAir)
@@ -42,11 +41,20 @@ public abstract class SingleSlotEntity : ModTileEntity
 			player.releaseUseItem = false;
 			player.mouseInterface = true;
 
-			if (lastItem != item && Main.netMode == NetmodeID.MultiplayerClient)
+			if (Main.netMode == NetmodeID.MultiplayerClient)
 				new SingleSlotData((short)ID, item).Send();
 		}
 
 		return success;
+	}
+
+	/// <summary> Removes <see cref="item"/> and automatically syncs it. </summary>
+	public void RemoveItem()
+	{
+		item.TurnToAir();
+
+		if (Main.netMode != NetmodeID.SinglePlayer)
+			new SingleSlotData((short)ID, item).Send();
 	}
 
 	public virtual bool CanAddItem(Item item) => true;

--- a/Common/Visuals/ForceWaterStyle.cs
+++ b/Common/Visuals/ForceWaterStyle.cs
@@ -6,7 +6,6 @@ namespace SpiritReforged.Common.Visuals;
 [Autoload(Side = ModSide.Client)]
 internal class WaterStyleSystem : ModSystem
 {
-	//private static int DeepOceanWaterStyle;
 	private static readonly HashSet<ModBackgroundStyle> Overrides = [];
 	private static readonly Dictionary<int, int> StyleSets = []; //background, water
 
@@ -21,20 +20,19 @@ internal class WaterStyleSystem : ModSystem
 		if (Main.dedServ)
 			return;
 
-		foreach (var scene in ModContent.GetContent<ModSceneEffect>())
+		foreach (var scene in Mod.GetContent<ModSceneEffect>()) //Patch transitions for our water styles
 		{
-			// Checks duplicate since not all mods set a surface background style
-			if (scene.SurfaceBackgroundStyle != null && scene.WaterStyle != null && !StyleSets.ContainsKey(scene.SurfaceBackgroundStyle.Slot))
-				StyleSets.Add(scene.SurfaceBackgroundStyle.Slot, scene.WaterStyle.Slot);
+			if (scene.SurfaceBackgroundStyle == null || scene.WaterStyle == null)
+				continue; //Checks duplicate since not all mods set a surface background style
+
+			StyleSets.TryAdd(scene.SurfaceBackgroundStyle.Slot, scene.WaterStyle.Slot);
 		}
 
-		foreach (var style in SpiritReforgedMod.Instance.GetContent<ModBackgroundStyle>())
+		foreach (var style in Mod.GetContent<ModBackgroundStyle>())
 		{
 			if (style is IWaterStyle)
 				Overrides.Add(style);
 		}
-
-		//DeepOceanWaterStyle = ModContent.GetInstance<DeepOceanBackgroundStyle>().Slot;
 	}
 
 	private static void SetWaterStyleDefault(ILContext il)
@@ -53,9 +51,6 @@ internal class WaterStyleSystem : ModSystem
 	/// <returns> The replacement water style. </returns>
 	private static int Modify(int style)
 	{
-		//if (Main.bgStyle == DeepOceanWaterStyle)
-		//	return DeepOceanBackgroundStyle.ChooseWaterStyle();
-
 		foreach (var set in StyleSets)
 		{
 			if (Main.bgStyle == set.Key)

--- a/Common/WorldGeneration/Ecotones/EcotoneEdgeDefinition.cs
+++ b/Common/WorldGeneration/Ecotones/EcotoneEdgeDefinition.cs
@@ -38,8 +38,8 @@ public class EcotoneEdgeDefinitions : ILoadable
 		AddEcotone(new EcotoneEdgeDefinition(TileID.CobaltBrick, "Ocean"));
 		AddEcotone(new EcotoneEdgeDefinition(TileID.SnowBlock, "Snow", TileID.SnowBlock, TileID.IceBlock));
 		AddEcotone(new EcotoneEdgeDefinition(TileID.ChlorophyteBrick, "Jungle", TileID.JungleGrass));
-		AddEcotone(new EcotoneEdgeDefinition(TileID.DemoniteBrick, "Corruption", TileID.CorruptGrass, TileID.Ebonsand, TileID.Ebonstone, TileID.CorruptIce));
-		AddEcotone(new EcotoneEdgeDefinition(TileID.CrimtaneBrick, "Crimson", TileID.CrimsonGrass, TileID.Crimsand, TileID.Crimstone, TileID.FleshIce));
+		AddEcotone(new EcotoneEdgeDefinition(TileID.DemoniteBrick, "Corruption", TileID.CorruptGrass, TileID.Ebonsand, TileID.Ebonstone, TileID.CorruptIce, TileID.CorruptJungleGrass));
+		AddEcotone(new EcotoneEdgeDefinition(TileID.CrimtaneBrick, "Crimson", TileID.CrimsonGrass, TileID.Crimsand, TileID.Crimstone, TileID.FleshIce, TileID.CrimsonJungleGrass));
 	}
 
 	public void Unload()

--- a/Common/WorldGeneration/Micropasses/Passes/FishingAreaMicropass.cs
+++ b/Common/WorldGeneration/Micropasses/Passes/FishingAreaMicropass.cs
@@ -14,8 +14,8 @@ internal class FishingAreaMicropass : Micropass
 		{ 4, [new Point16(23, 3), new Point16(4, 15), new Point16(51, 2), new Point16(49, 20)] }
 	};
 
-	[WorldBound]
-	public static HashSet<Rectangle> Coves = [];
+	//[WorldBound] //TEMP
+	public static readonly HashSet<Rectangle> Coves = [];
 	
 	public override string WorldGenName => "Fishing Coves";
 

--- a/Common/WorldGeneration/WorldBoundAttribute.cs
+++ b/Common/WorldGeneration/WorldBoundAttribute.cs
@@ -1,4 +1,6 @@
-﻿using System.Reflection;
+﻿using SpiritReforged.Common.WorldGeneration.Micropasses.Passes;
+using SpiritReforged.Content.Underground.Zipline;
+using System.Reflection;
 
 namespace SpiritReforged.Common.WorldGeneration;
 
@@ -26,5 +28,8 @@ internal class WorldBoundSystem : ModSystem
 	{
 		foreach (var info in Defaults.Keys)
 			info.SetValue(null, Defaults[info]);
+
+		FishingAreaMicropass.Coves.Clear(); //TEMPORARY! WorldBound preserves IEnumerables
+		ZiplineHandler.Ziplines.Clear();
 	}
 }

--- a/Content/Forest/Botanist/Tiles/Scarecrow.cs
+++ b/Content/Forest/Botanist/Tiles/Scarecrow.cs
@@ -1,5 +1,4 @@
 ﻿using MonoMod.Cil;
-using SpiritReforged.Common.ItemCommon;
 using SpiritReforged.Common.TileCommon;
 using SpiritReforged.Common.TileCommon.PresetTiles;
 using SpiritReforged.Common.TileCommon.TileSway;
@@ -49,15 +48,18 @@ public class Scarecrow : ModTile, IAutoloadTileItem, ISwayTile
 
 	public override void KillTile(int i, int j, ref bool fail, ref bool effectOnly, ref bool noItem)
 	{
-		if (!effectOnly && !Main.dedServ && ScarecrowSlot.GetMe(i, j) is ScarecrowSlot slot && !slot.item.IsAir)
+		if (effectOnly || Main.netMode == NetmodeID.MultiplayerClient)
+			return;
+
+		if (ScarecrowSlot.GetMe(i, j) is ScarecrowSlot slot && !slot.item.IsAir)
 		{
 			fail = true;
 			TileExtensions.GetTopLeft(ref i, ref j);
 
 			var pos = new Vector2(i, j).ToWorldCoordinates();
 
-			ItemMethods.NewItemSynced(new EntitySource_TileBreak(i, j), slot.item, pos);
-			slot.item.TurnToAir();
+			Item.NewItem(new EntitySource_TileBreak(i, j), pos, slot.item);
+			slot.RemoveItem();
 		}
 	}
 

--- a/Content/Jungle/Bamboo/Tiles/BambooBirdCage.cs
+++ b/Content/Jungle/Bamboo/Tiles/BambooBirdCage.cs
@@ -1,6 +1,7 @@
 using SpiritReforged.Common.ItemCommon;
 using SpiritReforged.Common.TileCommon;
 using SpiritReforged.Common.TileCommon.PresetTiles;
+using SpiritReforged.Content.Forest.Botanist.Tiles;
 using SpiritReforged.Content.Savanna.NPCs.Sparrow;
 using Terraria.Audio;
 using Terraria.DataStructures;
@@ -90,15 +91,18 @@ public class BambooBirdCage : ModTile, IAutoloadTileItem
 
 	public override void KillTile(int i, int j, ref bool fail, ref bool effectOnly, ref bool noItem) //Drop the contained bird, if any
 	{
-		if (!effectOnly && !Main.dedServ && Entity(i, j) is BambooBirdCageSlot slot && !slot.item.IsAir)
+		if (effectOnly || Main.netMode == NetmodeID.MultiplayerClient)
+			return;
+
+		if (Entity(i, j) is BambooBirdCageSlot slot && !slot.item.IsAir)
 		{
 			fail = true;
 			TileExtensions.GetTopLeft(ref i, ref j);
 
 			var pos = new Vector2(i, j).ToWorldCoordinates(16, 32);
 
-			ItemMethods.NewItemSynced(new EntitySource_TileBreak(i, j), slot.item, pos);
-			slot.item.TurnToAir();
+			Item.NewItem(new EntitySource_TileBreak(i, j), pos, slot.item);
+			slot.RemoveItem();
 		}
 	}
 

--- a/Content/Jungle/Bamboo/Tiles/StrippedBamboo.cs
+++ b/Content/Jungle/Bamboo/Tiles/StrippedBamboo.cs
@@ -25,9 +25,6 @@ public class StrippedBamboo : ModTile, IAutoloadTileItem
 		AddMapEntry(new Color(145, 128, 109));
 
 		this.AutoItem().ResearchUnlockCount = 100;
-
-		//Manually include for Classic compatibility because this item is autoloaded
-		if (SpiritClassic.Enabled && SpiritClassic.ClassicMod.TryFind("StrippedBamboo", out ModItem bamboo))
-			SpiritClassic.ClassicToReforged.Add(bamboo.Type, this.AutoItem().type);
+		SpiritClassic.AddReplacement("StrippedBamboo", this.AutoItem().type);
 	}
 }

--- a/Content/Ocean/Items/KoiTotem/KoiTotem.cs
+++ b/Content/Ocean/Items/KoiTotem/KoiTotem.cs
@@ -119,10 +119,12 @@ public class KoiTotemTile : ModTile, IDrawPreview
 
 			if (KoiTotem.CursorOpacity > .9f)
 			{
+				const string path = "SpiritReforged/Assets/SFX/Ambient/MagicFeedback";
+
 				ParticleHandler.SpawnParticle(new DissipatingImage(pos + new Vector2(18, 0), Color.Cyan * .15f, 0, .25f, 1f, "Bloom", 120));
 
-				SoundEngine.PlaySound(new SoundStyle("SpiritReforged/Assets/SFX/Ambient/MagicFeedback1") with { Volume = .3f, PitchRange = (-1, -.75f) }, pos);
-				SoundEngine.PlaySound(new SoundStyle("SpiritReforged/Assets/SFX/Ambient/MagicFeedback2") with { Volume = .4f, PitchRange = (-.35f, -.65f) }, pos);
+				SoundEngine.PlaySound(new SoundStyle(path + 1) with { Volume = .3f, PitchRange = (-1, -.75f) }, pos);
+				SoundEngine.PlaySound(new SoundStyle(path + 2) with { Volume = .4f, PitchRange = (-.65f, -.35f) }, pos);
 			}
 		}
 	}

--- a/Content/Ocean/Items/MineralSlag.cs
+++ b/Content/Ocean/Items/MineralSlag.cs
@@ -51,8 +51,6 @@ public class MineralSlag : ModItem
 		choice.Add(new ItemData(ItemID.GoldOre, Main.rand.Next(3) + 1), .5f);
 		choice.Add(new ItemData(ItemID.PlatinumOre, Main.rand.Next(3) + 1), .5f);
 
-		choice.Add(new ItemData(ItemID.AmberMosquito), .01f);
-
 		resultType = ((ItemData)choice).itemType;
 		resultStack = ((ItemData)choice).stack;
 	}

--- a/Content/Ocean/Items/SunkenTreasure.cs
+++ b/Content/Ocean/Items/SunkenTreasure.cs
@@ -192,7 +192,7 @@ public class SunkenTreasureTilePlaced : SunkenTreasureTile
 
 		DustType = DustID.Sand;
 		AddMapEntry(new Color(133, 106, 56), Language.GetText("Mods.SpiritReforged.Tiles.SunkenTreasureTilePlaced.MapEntry"));
-		SolidBottomTile.TileTypes.Add(Type);
+		//SolidBottomTile.TileTypes.Add(Type);
 	}
 
 	public override void MouseOver(int i, int j) { }

--- a/Content/Ocean/Tiles/Driftwood.cs
+++ b/Content/Ocean/Tiles/Driftwood.cs
@@ -25,8 +25,6 @@ public class Driftwood : ModTile, IAutoloadTileItem
 		CrateDatabase.AddCrateRule(ItemID.OceanCrate, ItemDropRule.Common(item.type, 5, 10, 30));
 		CrateDatabase.AddCrateRule(ItemID.OceanCrateHard, ItemDropRule.Common(item.type, 5, 10, 30));
 
-		//Manually include for Classic compatibility because this item is autoloaded
-		if (SpiritClassic.Enabled && SpiritClassic.ClassicMod.TryFind("DriftwoodTileItem", out ModItem driftwood))
-			SpiritClassic.ClassicToReforged.Add(driftwood.Type, this.AutoItem().type);
+		SpiritClassic.AddReplacement("DriftwoodTileItem", this.AutoItem().type);
 	}
 }

--- a/Content/Ocean/Tiles/Furniture/DriftwoodWorkBench.cs
+++ b/Content/Ocean/Tiles/Furniture/DriftwoodWorkBench.cs
@@ -11,9 +11,6 @@ public class DriftwoodWorkBench : WorkBenchTile
 	public override void StaticDefaults()
 	{
 		base.StaticDefaults();
-
-		//Manually include for Classic compatibility because this item is autoloaded
-		if (SpiritClassic.Enabled && SpiritClassic.ClassicMod.TryFind("DriftwoodWorkbenchItem", out ModItem workbench))
-			SpiritClassic.ClassicToReforged.Add(workbench.Type, this.AutoItem().type);
+		SpiritClassic.AddReplacement("DriftwoodWorkbenchItem", this.AutoItem().type);
 	}
 }

--- a/Content/Savanna/Biome/SavannaBiome.cs
+++ b/Content/Savanna/Biome/SavannaBiome.cs
@@ -17,6 +17,8 @@ public class SavannaBiome : ModBiome
 	public override void SetStaticDefaults() => NPCHappinessHelper.SetAverage<SavannaBiome>(ModContent.GetInstance<JungleBiome>(), ModContent.GetInstance<DesertBiome>());
 
 	public override SceneEffectPriority Priority => SceneEffectPriority.BiomeMedium;
+	public override float GetWeight(Player player) => .75f;
+
 	public override int Music => GetMusic();
 	public override ModWaterStyle WaterStyle => ModContent.GetInstance<SavannaWaterStyle>();
 	public override ModSurfaceBackgroundStyle SurfaceBackgroundStyle => ModContent.GetInstance<SavannaBGStyle>();

--- a/Content/Savanna/Ecotone/SavannaEcotone.cs
+++ b/Content/Savanna/Ecotone/SavannaEcotone.cs
@@ -467,7 +467,12 @@ internal class SavannaEcotone : EcotoneBase
 
 	private static bool OnBaobab(int i, int j)
 	{
-		int belowType = Main.tile[i, j + 1].TileType;
+		var t = Framing.GetTileSafely(i, j + 1);
+
+		if (!t.HasTile)
+			return false;
+
+		int belowType = t.TileType;
 		return belowType == ModContent.TileType<LivingBaobab>() || belowType == ModContent.TileType<LivingBaobabLeaf>();
 	}
 

--- a/Content/Savanna/Items/CampfireSpit.cs
+++ b/Content/Savanna/Items/CampfireSpit.cs
@@ -1,6 +1,7 @@
 using SpiritReforged.Common.ItemCommon;
 using SpiritReforged.Common.TileCommon;
 using SpiritReforged.Common.TileCommon.PresetTiles;
+using SpiritReforged.Content.Jungle.Bamboo.Tiles;
 using SpiritReforged.Content.Vanilla.Food;
 using Terraria.Audio;
 using Terraria.DataStructures;
@@ -192,16 +193,23 @@ public class RoastGlobalTile : GlobalTile
 
 	public override void KillTile(int i, int j, int type, ref bool fail, ref bool effectOnly, ref bool noItem)
 	{
-		if (!effectOnly && !Main.dedServ && Entity(i, j) is CampfireSlot slot)
+		if (effectOnly || Main.netMode == NetmodeID.MultiplayerClient)
+			return;
+
+		if (Entity(i, j) is CampfireSlot slot)
 		{
 			fail = true;
 			TileExtensions.GetTopLeft(ref i, ref j);
 
 			var pos = new Vector2(i, j).ToWorldCoordinates() + new Vector2(16);
-			ItemMethods.NewItemSynced(new EntitySource_TileBreak(i, j), ModContent.ItemType<CampfireSpit>(), pos);
+
+			Item.NewItem(new EntitySource_TileBreak(i, j), pos, ModContent.ItemType<CampfireSpit>());
 
 			if (!slot.item.IsAir)
-				ItemMethods.NewItemSynced(new EntitySource_TileBreak(i, j), slot.item, pos);
+			{
+				Item.NewItem(new EntitySource_TileBreak(i, j), pos, slot.item);
+				//slot.RemoveItem(); //Unecessary
+			}
 
 			slot.Kill(i, j);
 		}

--- a/Content/Savanna/Tiles/SavannaDirt.cs
+++ b/Content/Savanna/Tiles/SavannaDirt.cs
@@ -49,13 +49,25 @@ public class SavannaDirt : ModTile, IAutoloadTileItem, ICheckItemUse
 
 	public bool? CheckItemUse(int type, int i, int j)
 	{
-		if (type == ItemID.StaffofRegrowth) //Staff of Regrowth functionality
+		switch (type)
 		{
-			WorldGen.PlaceTile(i, j, ModContent.TileType<SavannaGrass>(), forced: true);
-			NetMessage.SendTileSquare(-1, i, j);
-			return true;
+			case ItemID.StaffofRegrowth:
+				WorldGen.PlaceTile(i, j, ModContent.TileType<SavannaGrass>(), forced: true);
+				break;
+			case ItemID.CorruptSeeds:
+				WorldGen.PlaceTile(i, j, ModContent.TileType<SavannaGrassCorrupt>(), forced: true);
+				break;
+			case ItemID.CrimsonSeeds:
+				WorldGen.PlaceTile(i, j, ModContent.TileType<SavannaGrassCrimson>(), forced: true);
+				break;
+			case ItemID.HallowedSeeds:
+				WorldGen.PlaceTile(i, j, ModContent.TileType<SavannaGrassHallow>(), forced: true);
+				break;
+			default:
+				return null;
 		}
 
-		return null;
+		NetMessage.SendTileSquare(-1, i, j);
+		return true;
 	}
 }

--- a/Content/Underground/Zipline/ZipRemovalData.cs
+++ b/Content/Underground/Zipline/ZipRemovalData.cs
@@ -25,12 +25,12 @@ internal class ZipRemovalData : PacketData
 	/// <summary> Removes all ziplines owned by <paramref name="playerIndex"/>. </summary>
 	public static void RemoveZiplines(short playerIndex)
 	{
-		foreach (var zipline in ZiplineHandler.ziplines)
+		foreach (var zipline in ZiplineHandler.Ziplines)
 		{
 			if (zipline.Owner.whoAmI == playerIndex)
 			{
 				FX(zipline);
-				ZiplineHandler.ziplines.Remove(zipline);
+				ZiplineHandler.Ziplines.Remove(zipline);
 			}
 		}
 

--- a/Content/Underground/Zipline/Zipline.cs
+++ b/Content/Underground/Zipline/Zipline.cs
@@ -70,7 +70,7 @@ internal class Zipline(int owner)
 		points.Remove(point);
 
 		if (points.Count == 0)
-			ZiplineHandler.ziplines.Remove(this);
+			ZiplineHandler.Ziplines.Remove(this);
 	}
 
 	public void Draw(SpriteBatch spriteBatch)

--- a/Content/Underground/Zipline/ZiplineGun.cs
+++ b/Content/Underground/Zipline/ZiplineGun.cs
@@ -56,7 +56,7 @@ public class ZiplineGun : ModItem
 	/// <summary> Checks whether <see cref="Main.MouseWorld"/> is hovering over a removeable zipline. </summary>
 	private static bool CheckRemoveable()
 	{
-		foreach (var zipline in ZiplineHandler.ziplines)
+		foreach (var zipline in ZiplineHandler.Ziplines)
 		{
 			if (zipline.Owner == Main.LocalPlayer && zipline.Contains(Main.MouseWorld.ToPoint(), out _))
 				return true;
@@ -72,7 +72,7 @@ public class ZiplineGun : ModItem
 		const int minDistance = 70;
 
 		exceedsRange = false;
-		var myZipline = ZiplineHandler.ziplines.Where(x => x.Owner == Main.LocalPlayer).FirstOrDefault();
+		var myZipline = ZiplineHandler.Ziplines.Where(x => x.Owner == Main.LocalPlayer).FirstOrDefault();
 
 		if (myZipline == default || myZipline.points.Count == 0)
 			return true;
@@ -90,7 +90,7 @@ public class ZiplineGun : ModItem
 	/// <summary> Checks if the angle of the zipline is within <see cref="Zipline.MaxAngle"/>. </summary>
 	private static bool CheckAngle()
 	{
-		var myZipline = ZiplineHandler.ziplines.Where(x => x.Owner == Main.LocalPlayer).FirstOrDefault();
+		var myZipline = ZiplineHandler.Ziplines.Where(x => x.Owner == Main.LocalPlayer).FirstOrDefault();
 
 		if (myZipline == default || myZipline.points.Count == 0)
 			return true;
@@ -165,7 +165,7 @@ public class ZiplineGun : ModItem
 		{
 			const int chunkWidth = 16;
 
-			var myZipline = ZiplineHandler.ziplines.Where(x => x.Owner == Main.LocalPlayer).FirstOrDefault();
+			var myZipline = ZiplineHandler.Ziplines.Where(x => x.Owner == Main.LocalPlayer).FirstOrDefault();
 			if (myZipline == default || myZipline.points.Count == 0)
 				return;
 
@@ -245,7 +245,7 @@ public class ZiplineGun : ModItem
 		return false;
 	}
 
-	public override bool AltFunctionUse(Player player) => ZiplineHandler.ziplines.Where(x => x.Owner == player).Any();
+	public override bool AltFunctionUse(Player player) => ZiplineHandler.Ziplines.Where(x => x.Owner == player).Any();
 	public override bool? UseItem(Player player)
 	{
 		if (player.altFunctionUse == 2)

--- a/Content/Underground/Zipline/ZiplineHandler.cs
+++ b/Content/Underground/Zipline/ZiplineHandler.cs
@@ -1,6 +1,6 @@
-﻿using SpiritReforged.Common.ItemCommon.Pins;
-using SpiritReforged.Common.Particle;
+﻿using SpiritReforged.Common.Particle;
 using SpiritReforged.Common.PlayerCommon;
+using SpiritReforged.Common.WorldGeneration;
 using SpiritReforged.Content.Particles;
 using System.Linq;
 using Terraria.Audio;
@@ -16,21 +16,22 @@ internal class ZiplineHandler : ILoadable
 
 	/// <summary> <see cref="Zipline"/>s belonging to all players.<para/>
 	/// Use <see cref="Add"/> and <see cref="Zipline.RemovePoint"/> instead of directly adding and removing points from this set. </summary>
-	public static readonly HashSet<Zipline> ziplines = [];
+	//[WorldBound]
+	public static readonly HashSet<Zipline> Ziplines = [];
 
 	/// <summary> Creates a new zipline at <paramref name="position"/> or adds to an existing zipline belonging to <paramref name="player"/>. </summary>
 	/// <param name="player"> The zipline owner. </param>
 	/// <param name="position"> The position to deploy at. </param>
 	public static void Add(Player player, Vector2 position)
 	{
-		var line = ziplines.Where(x => x.Owner == player).FirstOrDefault();
+		var line = Ziplines.Where(x => x.Owner == player).FirstOrDefault();
 
 		if (line == default) //Add a new zipline
 		{
 			var newLine = new Zipline(player.whoAmI);
 			newLine.points.Add(position);
 
-			ziplines.Add(newLine);
+			Ziplines.Add(newLine);
 		}
 		else
 		{
@@ -56,14 +57,14 @@ internal class ZiplineHandler : ILoadable
 	{
 		orig(self);
 
-		foreach (var zipline in ziplines)
+		foreach (var zipline in Ziplines)
 			zipline.Draw(Main.spriteBatch);
 	}
 
 	public static bool CheckZipline(Player player, out Zipline thisZipline)
 	{
 		thisZipline = null;
-		foreach (var zipline in ziplines)
+		foreach (var zipline in Ziplines)
 		{
 			if (zipline.OnZipline(player))
 			{

--- a/Content/Underground/Zipline/ZiplineProj.cs
+++ b/Content/Underground/Zipline/ZiplineProj.cs
@@ -38,7 +38,7 @@ public class ZiplineProj : ModProjectile
 			return; //Don't interact with rails after timing out for whatever reason
 
 		bool removed = false;
-		foreach (var zipline in ZiplineHandler.ziplines)
+		foreach (var zipline in ZiplineHandler.Ziplines)
 		{
 			if (zipline.Owner == Main.player[Projectile.owner])
 				UpdateExisting(zipline, out removed);
@@ -64,7 +64,7 @@ public class ZiplineProj : ModProjectile
 			var last = zipline.points.Last();
 
 			if ((last / 16).Distance(Main.MouseWorld / 16) > ZiplineGun.ExceedDist + .5f)
-				ZiplineHandler.ziplines.Remove(zipline); //Remove the last rail if distance is excessive
+				ZiplineHandler.Ziplines.Remove(zipline); //Remove the last rail if distance is excessive
 		}
 	}
 

--- a/Localization/en-US_Mods.SpiritReforged.Items.hjson
+++ b/Localization/en-US_Mods.SpiritReforged.Items.hjson
@@ -24,7 +24,11 @@ PirateKey: {
 
 RawFish: {
 	DisplayName: Raw Fish
-	Tooltip: "'Can be eaten...maybe cook it first?'"
+	Tooltip:
+		'''
+		{$BuffDescription.WellFed}
+		'Can be eaten...maybe cook it first?'
+		'''
 }
 
 SunkenTreasure: {
@@ -195,7 +199,11 @@ CrystalFish: {
 
 RawMeat: {
 	DisplayName: Raw Meat
-	Tooltip: "'Can be eaten...maybe cook it first?'"
+	Tooltip:
+		'''
+		{$BuffDescription.WellFed}
+		'Can be eaten...maybe cook it first?'
+		'''
 }
 
 CookedMeat: {
@@ -515,12 +523,12 @@ LeatherBackpack: {
 
 Caryocar: {
 	DisplayName: Caryocar
-	Tooltip: ""
+	Tooltip: "{$BuffDescription.WellFed}"
 }
 
 CustardApple: {
 	DisplayName: Custard Apple
-	Tooltip: ""
+	Tooltip: "{$BuffDescription.WellFed}"
 }
 
 BeachUmbrellaItem: {


### PR DESCRIPTION
- Fixed a crash caused by nearby Koi Totems when fishing
- Fixed a potential crash when loading mod water styles
- Included alternate jungle grass types in Ecotone surface mapping
- Fixed Scarecrow item drops syncing incorrectly in multiplayer
- Increased Savanna scene weight slightly
- Included "Well Fed" buff descriptions for several items
- Rail-Gun rails no longer persist when switching worlds
- Sunken Treasure no longer modifies framing of surface tiles when placed