### PR TITLE
Dyeable backpacks

### DIFF
--- a/Common/ItemCommon/Backpacks/BackpackPlayer.cs
+++ b/Common/ItemCommon/Backpacks/BackpackPlayer.cs
@@ -51,22 +51,25 @@ internal class BackpackPlayer : ModPlayer
 			}
 		}
 
-		// Track current & old state so we can sync as needed
+		if (Main.netMode == NetmodeID.MultiplayerClient)
+		{
+			// Track current & old state so we can sync as needed
 
-		_oldState = _state;
-		_state = BackpackState.None;
+			_oldState = _state;
+			_state = BackpackState.None;
 
-		if (backpack != null && !backpack.IsAir)
-			_state |= BackpackState.HasBackpack;
+			if (backpack != null && !backpack.IsAir)
+				_state |= BackpackState.HasBackpack;
 
-		if (vanityBackpack != null && !vanityBackpack.IsAir)
-			_state |= BackpackState.HasVanity;
+			if (vanityBackpack != null && !vanityBackpack.IsAir)
+				_state |= BackpackState.HasVanity;
 
-		if (packDye != null && !packDye.IsAir)
-			_state |= BackpackState.HasDye;
+			if (packDye != null && !packDye.IsAir)
+				_state |= BackpackState.HasDye;
 
-		if (_oldState != _state)
-			new BackpackPlayerData(packVisible, (byte)Player.whoAmI).Send();
+			if (_oldState != _state)
+				new BackpackPlayerData(packVisible, (byte)Player.whoAmI).Send();
+		}
 	}
 
 	public override void FrameEffects() //This way, players can be seen wearing backpacks in the selection screen

--- a/Common/ItemCommon/Backpacks/BackpackPlayer.cs
+++ b/Common/ItemCommon/Backpacks/BackpackPlayer.cs
@@ -9,6 +9,7 @@ internal class BackpackPlayer : ModPlayer
 {
 	public Item backpack = new();
 	public Item vanityBackpack = new();
+	public Item packDye = new();
 	public bool packVisible = true;
 
 	private int _lastSelectedEquipPage = 0;
@@ -53,6 +54,12 @@ internal class BackpackPlayer : ModPlayer
 	{
 		Player.back = EquipLoader.GetEquipSlot(Mod, backpack.ModItem.Name, EquipType.Back);
 		Player.front = EquipLoader.GetEquipSlot(Mod, backpack.ModItem.Name, EquipType.Front);
+
+		if (!packDye.IsAir) 
+		{
+			Player.cBack = packDye.dye;
+			Player.cFront = packDye.dye;
+		}
 	}
 
 	public override void SaveData(TagCompound tag)
@@ -62,6 +69,9 @@ internal class BackpackPlayer : ModPlayer
 
 		if (vanityBackpack is not null)
 			tag.Add("vanity", ItemIO.Save(vanityBackpack));
+		
+		if (packDye is not null)
+			tag.Add("dye", ItemIO.Save(packDye));
 
 		tag.Add(nameof(packVisible), packVisible);
 	}
@@ -73,6 +83,9 @@ internal class BackpackPlayer : ModPlayer
 
 		if (tag.TryGet("vanity", out TagCompound vanity))
 			vanityBackpack = ItemIO.Load(vanity);
+
+		if (tag.TryGet("dye", out TagCompound dye))
+			packDye = ItemIO.Load(dye);
 
 		packVisible = tag.Get<bool>(nameof(packVisible));
 	}

--- a/Common/UI/BackpackInterface/BackbackUISlot.cs
+++ b/Common/UI/BackpackInterface/BackbackUISlot.cs
@@ -149,7 +149,7 @@ public class BackpackUISlot : UIElement
 				SoundEngine.PlaySound(SoundID.MenuTick);
 
 				if (Main.netMode == NetmodeID.MultiplayerClient)
-					new PackVisibilityData(mPlayer.packVisible, (byte)Main.myPlayer).Send();
+					new BackpackPlayerData(mPlayer.packVisible, (byte)Main.myPlayer).Send();
 				//NetMessage.SendData(MessageID.SyncPlayer, -1, -1, null, Main.myPlayer);
 			}
 

--- a/Common/UI/BackpackInterface/BackbackUISlot.cs
+++ b/Common/UI/BackpackInterface/BackbackUISlot.cs
@@ -46,10 +46,10 @@ public class BackpackUISlot : UIElement
 			Texture2D texture;
 			Rectangle source;
 
-			if (_isVanity)
+			if (_isVanity || _isDye)
 			{
 				texture = TextureAssets.Extra[54].Value;
-				source = texture.Frame(3, 6, 2, 0, -2, -2);
+				source = texture.Frame(3, 6, _isDye ? 1 : 2, 0, -2, -2);
 			}
 			else
 			{
@@ -84,14 +84,14 @@ public class BackpackUISlot : UIElement
 
 		if (Main.mouseLeft && Main.mouseLeftRelease && CanClickItem(item, _isVanity, _isDye))
 		{
-			ItemSlot.LeftClick(ref item, ItemSlot.Context.InventoryItem); //Don't use Context because it causes issues in multiplayer due to syncing
+			ItemSlot.LeftClick(ref item, _isDye ? ItemSlot.Context.EquipMiscDye : ItemSlot.Context.InventoryItem); //Don't use Context because it causes issues in multiplayer due to syncing
 			ItemSlot.RightClick(ref item, Context);
 		}
 
 		if (item.IsAir)
 		{
 			Main.mouseText = true;
-			Main.hoverItemName = Language.GetTextValue("Mods.SpiritReforged.SlotContexts.Backpack");
+			Main.hoverItemName = _isDye ? Lang.inter[57].Value : Language.GetTextValue("Mods.SpiritReforged.SlotContexts.Backpack");
 		}
 	}
 
@@ -103,8 +103,7 @@ public class BackpackUISlot : UIElement
 
 		if (isDye)
 		{
-			if (currentItem.IsAir)
-				return plr.HeldItem.dye > 0;
+			return plr.HeldItem.dye > 0 || Main.mouseItem.IsAir;
 		}
 		else if (vanity)
 		{

--- a/Common/UI/BackpackInterface/BackpackUIState.cs
+++ b/Common/UI/BackpackInterface/BackpackUIState.cs
@@ -1,6 +1,7 @@
 ﻿using SpiritReforged.Common.ItemCommon.Backpacks;
 using SpiritReforged.Common.UI.Misc;
 using SpiritReforged.Common.UI.System;
+using System.Net.NetworkInformation;
 using Terraria.GameContent.UI.Elements;
 using Terraria.UI;
 
@@ -10,6 +11,7 @@ internal class BackpackUIState : AutoUIState
 {
 	private BackpackUISlot _functionalSlot;
 	private BackpackUISlot _vanitySlot;
+	private BackpackUISlot _dyeSlot;
 
 	private Item _lastBackpack;
 	private int _lastAdjustY;
@@ -25,6 +27,10 @@ internal class BackpackUIState : AutoUIState
 		_vanitySlot = new BackpackUISlot(true);
 		_vanitySlot.Left = new StyleDimension(_functionalSlot.Left.Pixels - 48, 1);
 		Append(_vanitySlot);
+
+		_dyeSlot = new BackpackUISlot(false, true);
+		_dyeSlot.Left = new StyleDimension(_vanitySlot.Left.Pixels - 48, 1);
+		Append(_dyeSlot);
 
 		SetVariablePositions();
 
@@ -74,7 +80,7 @@ internal class BackpackUIState : AutoUIState
 		base.Update(gameTime);
 	}
 
-	private void SetVariablePositions() => _functionalSlot.Top = _vanitySlot.Top = new StyleDimension(UIHelper.GetMapHeight() + 174, 0);
+	private void SetVariablePositions() => _functionalSlot.Top = _vanitySlot.Top = _dyeSlot.Top = new StyleDimension(UIHelper.GetMapHeight() + 174, 0);
 
 	/// <summary> Adds or removes backpack slots with items according to the currently equipped backpack.<para/>
 	/// This is a snapshot, and must be called again if the <see cref="BackpackPlayer.backpack"/> instance has changed.<br/>
@@ -136,5 +142,13 @@ internal class BackpackUIState : AutoUIState
 				Append(newSlot);
 			}
 		}
+	}
+
+	protected override void DrawChildren(SpriteBatch spriteBatch)
+	{
+		float old = Main.inventoryScale;
+		Main.inventoryScale = 0.85f;
+		base.DrawChildren(spriteBatch);
+		Main.inventoryScale = old;
 	}
 }

--- a/Common/UI/BackpackInterface/BackpackUIState.cs
+++ b/Common/UI/BackpackInterface/BackpackUIState.cs
@@ -1,7 +1,6 @@
 ﻿using SpiritReforged.Common.ItemCommon.Backpacks;
 using SpiritReforged.Common.UI.Misc;
 using SpiritReforged.Common.UI.System;
-using System.Net.NetworkInformation;
 using Terraria.GameContent.UI.Elements;
 using Terraria.UI;
 

--- a/Common/UI/BackpackInterface/BackpackUIState.cs
+++ b/Common/UI/BackpackInterface/BackpackUIState.cs
@@ -142,12 +142,4 @@ internal class BackpackUIState : AutoUIState
 			}
 		}
 	}
-
-	protected override void DrawChildren(SpriteBatch spriteBatch)
-	{
-		float old = Main.inventoryScale;
-		Main.inventoryScale = 0.85f;
-		base.DrawChildren(spriteBatch);
-		Main.inventoryScale = old;
-	}
 }


### PR DESCRIPTION
- Adds in dye slot for backpacks
Note that this may also dye other things, but in 99% of cases the back and front slots will be used by backpacks unless some really weird crossmod code is happening.
- Syncs backpacks fully in mp - change visibility, unequip, equip, dye & undye with no inconsistencies