### PR TITLE
Scarecrow fix

### DIFF
--- a/Common/TileCommon/PresetTiles/SingleSlotEntity.cs
+++ b/Common/TileCommon/PresetTiles/SingleSlotEntity.cs
@@ -1,5 +1,7 @@
 ﻿using SpiritReforged.Common.ItemCommon;
 using SpiritReforged.Common.Multiplayer;
+using SpiritReforged.Content.Forest.Botanist.Tiles;
+using SpiritReforged.Content.Jungle.Bamboo.Tiles;
 using System.IO;
 using Terraria.DataStructures;
 using Terraria.ModLoader.IO;
@@ -124,5 +126,65 @@ internal class SingleSlotData : PacketData
 	{
 		modPacket.Write(_id);
 		ItemIO.Send(_item, modPacket);
+	}
+}
+
+/// <summary> Helper tile to be used in conjunction with <see cref="SingleSlotEntity"/>. </summary>
+public abstract class SingleSlotTile<T> : ModTile where T : SingleSlotEntity
+{
+	/// <summary> The <b>template</b> instance of the associated tile entity. if instanced data is required, use <see cref="Entity"/> instead. </summary>
+	protected SingleSlotEntity entity;
+
+	public int ItemType => (this is IAutoloadTileItem) ? this.AutoItem().type : ItemID.None;
+
+	public override void SetStaticDefaults() => entity = ModContent.GetInstance<T>();
+
+	/// <returns> Whether the multitile at the given position has a tile entity. </returns>
+	public T Entity(int i, int j)
+	{
+		if (Main.tile[i, j].TileType != Type)
+			return null;
+
+		TileExtensions.GetTopLeft(ref i, ref j);
+		int id = ModContent.GetInstance<T>().Find(i, j);
+
+		return (id == -1) ? null : (T)TileEntity.ByID[id];
+	}
+
+	public override void KillTile(int i, int j, ref bool fail, ref bool effectOnly, ref bool noItem)
+	{
+		if (effectOnly)
+			return;
+
+		if (Entity(i, j) is T slot && !slot.item.IsAir)
+		{
+			fail = true;
+
+			if (Main.netMode != NetmodeID.MultiplayerClient)
+			{
+				TileExtensions.GetTopLeft(ref i, ref j);
+
+				var pos = new Vector2(i, j).ToWorldCoordinates();
+
+				Item.NewItem(new EntitySource_TileBreak(i, j), pos, slot.item);
+				slot.RemoveItem();
+			}
+		}
+	}
+
+	public override bool RightClick(int i, int j)
+	{
+		if (Entity(i, j) is T entity)
+			entity.OnInteract(Main.LocalPlayer);
+
+		return true;
+	}
+
+	public override void MouseOver(int i, int j)
+	{
+		Player player = Main.LocalPlayer;
+		player.noThrow = 2;
+		player.cursorItemIconEnabled = true;
+		player.cursorItemIconID = (Entity(i, j) is not T entity || entity.item.IsAir) ? ItemType : entity.item.type;
 	}
 }

--- a/Content/Jungle/Bamboo/Tiles/BambooBirdCage.cs
+++ b/Content/Jungle/Bamboo/Tiles/BambooBirdCage.cs
@@ -1,7 +1,6 @@
 using SpiritReforged.Common.ItemCommon;
 using SpiritReforged.Common.TileCommon;
 using SpiritReforged.Common.TileCommon.PresetTiles;
-using SpiritReforged.Content.Forest.Botanist.Tiles;
 using SpiritReforged.Content.Savanna.NPCs.Sparrow;
 using Terraria.Audio;
 using Terraria.DataStructures;
@@ -9,23 +8,9 @@ using Terraria.GameContent.ObjectInteractions;
 
 namespace SpiritReforged.Content.Jungle.Bamboo.Tiles;
 
-public class BambooBirdCage : ModTile, IAutoloadTileItem
+public class BambooBirdCage : SingleSlotTile<BambooBirdCageSlot>, IAutoloadTileItem
 {
-	private int ItemType => this.AutoItem().type;
-
 	internal static HashSet<int> BirdTypes;
-
-	/// <returns> Whether the multitile at the given position has a tile entity. </returns>
-	private TileEntity Entity(int i, int j)
-	{
-		if (Main.tile[i, j].TileType != Type)
-			return null;
-
-		TileExtensions.GetTopLeft(ref i, ref j);
-		int id = ModContent.GetInstance<BambooBirdCageSlot>().Find(i, j);
-
-		return (id == -1) ? null : TileEntity.ByID[id];
-	}
 
 	public void SetItemDefaults(ModItem item)
 	{
@@ -35,8 +20,8 @@ public class BambooBirdCage : ModTile, IAutoloadTileItem
 		item.Item.value = 50;
 	}
 
-	public void AddItemRecipes(ModItem item) => item.CreateRecipe().AddIngredient(ItemMethods.AutoItemType<StrippedBamboo>(), 14)
-		.AddTile(TileID.Sawmill).Register();
+	public void AddItemRecipes(ModItem item) => item.CreateRecipe()
+		.AddIngredient(ItemMethods.AutoItemType<StrippedBamboo>(), 14).AddTile(TileID.Sawmill).Register();
 
 	public override void SetStaticDefaults()
 	{
@@ -79,53 +64,6 @@ public class BambooBirdCage : ModTile, IAutoloadTileItem
 	}
 
 	public override bool HasSmartInteract(int i, int j, SmartInteractScanSettings settings) => true;
-
-	public override void KillMultiTile(int i, int j, int frameX, int frameY)
-	{
-		if (Entity(i, j) is BambooBirdCageSlot slot)
-		{
-			if (!slot.item.IsAir)
-				Item.NewItem(new EntitySource_TileBreak(i, j), new Rectangle(i * 16, j * 16, 16 * 2, 16 * 3), slot.item);
-		}
-	}
-
-	public override void KillTile(int i, int j, ref bool fail, ref bool effectOnly, ref bool noItem) //Drop the contained bird, if any
-	{
-		if (effectOnly || Main.netMode == NetmodeID.MultiplayerClient)
-			return;
-
-		if (Entity(i, j) is BambooBirdCageSlot slot && !slot.item.IsAir)
-		{
-			fail = true;
-			TileExtensions.GetTopLeft(ref i, ref j);
-
-			var pos = new Vector2(i, j).ToWorldCoordinates(16, 32);
-
-			Item.NewItem(new EntitySource_TileBreak(i, j), pos, slot.item);
-			slot.RemoveItem();
-		}
-	}
-
-	public override bool RightClick(int i, int j)
-	{
-		if (Entity(i, j) is BambooBirdCageSlot slot)
-			return slot.OnInteract(Main.LocalPlayer);
-
-		return false;
-	}
-
-	public override void MouseOver(int i, int j)
-	{
-		Player player = Main.LocalPlayer;
-
-		if (Entity(i, j) is BambooBirdCageSlot slot && !slot.item.IsAir)
-			player.cursorItemIconID = slot.item.type;
-		else
-			player.cursorItemIconID = ItemType;
-
-		player.noThrow = 2;
-		player.cursorItemIconEnabled = true;
-	}
 
 	public override void NearbyEffects(int i, int j, bool closer)
 	{

--- a/Content/Savanna/Items/CampfireSpit.cs
+++ b/Content/Savanna/Items/CampfireSpit.cs
@@ -193,25 +193,25 @@ public class RoastGlobalTile : GlobalTile
 
 	public override void KillTile(int i, int j, int type, ref bool fail, ref bool effectOnly, ref bool noItem)
 	{
-		if (effectOnly || Main.netMode == NetmodeID.MultiplayerClient)
+		if (effectOnly)
 			return;
 
 		if (Entity(i, j) is CampfireSlot slot)
 		{
 			fail = true;
-			TileExtensions.GetTopLeft(ref i, ref j);
 
-			var pos = new Vector2(i, j).ToWorldCoordinates() + new Vector2(16);
-
-			Item.NewItem(new EntitySource_TileBreak(i, j), pos, ModContent.ItemType<CampfireSpit>());
-
-			if (!slot.item.IsAir)
+			if (Main.netMode != NetmodeID.MultiplayerClient)
 			{
-				Item.NewItem(new EntitySource_TileBreak(i, j), pos, slot.item);
-				//slot.RemoveItem(); //Unecessary
-			}
+				TileExtensions.GetTopLeft(ref i, ref j);
 
-			slot.Kill(i, j);
+				var pos = new Vector2(i, j).ToWorldCoordinates() + new Vector2(16);
+				Item.NewItem(new EntitySource_TileBreak(i, j), pos, ModContent.ItemType<CampfireSpit>());
+
+				if (!slot.item.IsAir)
+					Item.NewItem(new EntitySource_TileBreak(i, j), pos, slot.item);
+
+				slot.Kill(i, j);
+			}
 		}
 	}
 


### PR DESCRIPTION
Fixes a crash caused by Scarecrow when destroyed with a hat equipped in multiplayer + included an additional tile helper.