### PR TITLE
Thorium compat

### DIFF
--- a/Common/ModCompat/ThoriumCompat.cs
+++ b/Common/ModCompat/ThoriumCompat.cs
@@ -1,0 +1,14 @@
+﻿namespace SpiritReforged.Common.ModCompat;
+
+internal class ThoriumCompat : ModSystem
+{
+	public static Mod Instance;
+	public static bool Enabled => Instance != null;
+
+	public override void Load()
+	{
+		Instance = null;
+		if (!ModLoader.TryGetMod("ThoriumMod", out Instance))
+			return;
+	}
+}

--- a/Common/ModCompat/ThoriumCompat.cs
+++ b/Common/ModCompat/ThoriumCompat.cs
@@ -1,6 +1,11 @@
 ﻿
+using SpiritReforged.Common.Misc;
+using SpiritReforged.Content.Forest.Cloud.Items;
 using SpiritReforged.Content.Ocean.Items.JellyfishStaff;
+using SpiritReforged.Content.Savanna.Tiles.Paintings;
+using SpiritReforged.Content.Underground.ExplorerTreads;
 using SpiritReforged.Content.Vanilla.Food;
+using Terraria;
 using Terraria.ModLoader;
 
 namespace SpiritReforged.Common.ModCompat;
@@ -34,6 +39,24 @@ internal class ThoriumGlobalNPC : GlobalNPC
 			{
 				if (npc.type == bigJellyfish.Type)
 					npcLoot.AddCommon(ModContent.ItemType<JellyfishStaff>(), 50);
+			}
+		}
+	}
+
+	public override void ModifyShop(NPCShop shop)
+	{
+		if (ThoriumCompat.Enabled)
+		{
+			if (ThoriumCompat.Instance.TryFind("Cobbler", out ModNPC cobbler))
+			{
+				if (shop.NpcType == cobbler.Type)
+					shop.Add(ModContent.ItemType<ExplorerTreadsItem>(), Condition.DownedEyeOfCthulhu);
+			}
+
+			if (ThoriumCompat.Instance.TryFind("Druid", out ModNPC druid))
+			{
+				if (shop.NpcType == druid.Type)
+					shop.Add(ModContent.ItemType<CloudstalkSeed>(), Condition.DownedEyeOfCthulhu);
 			}
 		}
 	}

--- a/Common/ModCompat/ThoriumCompat.cs
+++ b/Common/ModCompat/ThoriumCompat.cs
@@ -1,11 +1,16 @@
 ﻿
+using SpiritReforged.Common.ItemCommon;
 using SpiritReforged.Common.Misc;
 using SpiritReforged.Content.Forest.Cloud.Items;
+using SpiritReforged.Content.Ocean.Items;
 using SpiritReforged.Content.Ocean.Items.JellyfishStaff;
+using SpiritReforged.Content.Savanna.Items.Food;
+using SpiritReforged.Content.Savanna.Tiles;
 using SpiritReforged.Content.Savanna.Tiles.Paintings;
 using SpiritReforged.Content.Underground.ExplorerTreads;
 using SpiritReforged.Content.Vanilla.Food;
 using Terraria;
+using Terraria.DataStructures;
 using Terraria.ModLoader;
 
 namespace SpiritReforged.Common.ModCompat;
@@ -58,6 +63,18 @@ internal class ThoriumGlobalNPC : GlobalNPC
 				if (shop.NpcType == druid.Type)
 					shop.Add(ModContent.ItemType<CloudstalkSeed>(), Condition.DownedEyeOfCthulhu);
 			}
+		}
+	}
+}
+
+internal class ThoriumGlobalTile : GlobalTile
+{
+	public override void KillTile(int i, int j, int type, ref bool fail, ref bool effectOnly, ref bool noItem)
+	{
+		if (ThoriumCompat.Enabled && ThoriumCompat.Instance.TryFind("LivingLeaf", out ModItem livingLeaf))
+		{
+			if (type == ModContent.TileType<LivingBaobabLeaf>() && Main.rand.NextBool(3))
+				ItemMethods.NewItemSynced(new EntitySource_TileBreak(i, j), livingLeaf.Type, new Rectangle(i * 16, j * 16, 16, 16).Center(), true);
 		}
 	}
 }

--- a/Common/ModCompat/ThoriumCompat.cs
+++ b/Common/ModCompat/ThoriumCompat.cs
@@ -1,23 +1,14 @@
-﻿
-using SpiritReforged.Common.ItemCommon;
-using SpiritReforged.Common.Misc;
-using SpiritReforged.Content.Forest.Cloud.Items;
-using SpiritReforged.Content.Ocean.Items;
+﻿using SpiritReforged.Content.Forest.Cloud.Items;
 using SpiritReforged.Content.Ocean.Items.JellyfishStaff;
-using SpiritReforged.Content.Savanna.Items.Food;
 using SpiritReforged.Content.Savanna.Tiles;
-using SpiritReforged.Content.Savanna.Tiles.Paintings;
 using SpiritReforged.Content.Underground.ExplorerTreads;
-using SpiritReforged.Content.Vanilla.Food;
-using Terraria;
 using Terraria.DataStructures;
-using Terraria.ModLoader;
 
 namespace SpiritReforged.Common.ModCompat;
 
 internal class ThoriumCompat : ILoadable
 {
-	public static Mod Instance;
+	internal static Mod Instance;
 	public static bool Enabled => Instance != null;
 
 	public void Load(Mod mod)
@@ -34,58 +25,57 @@ internal class ThoriumGlobalNPC : GlobalNPC
 {
 	public override void ModifyNPCLoot(NPC npc, NPCLoot npcLoot)
 	{
-		if (ThoriumCompat.Enabled)
-		{
-			if (ThoriumCompat.Instance.TryFind("RagingMinotaur", out ModNPC minotaur))
-			{
-				if (npc.type == minotaur.Type)
-					npcLoot.AddCommon(ItemID.Leather, 1, 5, 10);
-			}
+		if (!ThoriumCompat.Enabled)
+			return;
 
-			if (ThoriumCompat.Instance.TryFind("ManofWar", out ModNPC bigJellyfish))
-			{
-				if (npc.type == bigJellyfish.Type)
-					npcLoot.AddCommon(ModContent.ItemType<JellyfishStaff>(), 50);
-			}
-		}
+		if (ThoriumCompat.Instance.TryFind("RagingMinotaur", out ModNPC minotaur) && npc.type == minotaur.Type)
+			npcLoot.AddCommon(ItemID.Leather, 1, 5, 10);
+
+		if (ThoriumCompat.Instance.TryFind("ManofWar", out ModNPC bigJellyfish) && npc.type == bigJellyfish.Type)
+			npcLoot.AddCommon(ModContent.ItemType<JellyfishStaff>(), 50);
 	}
 
 	public override void ModifyShop(NPCShop shop)
 	{
-		if (ThoriumCompat.Enabled)
-		{
-			if (ThoriumCompat.Instance.TryFind("Cobbler", out ModNPC cobbler))
-			{
-				if (shop.NpcType == cobbler.Type)
-					shop.Add(ModContent.ItemType<ExplorerTreadsItem>(), Condition.DownedEyeOfCthulhu);
-			}
+		if (!ThoriumCompat.Enabled)
+			return;
 
-			if (ThoriumCompat.Instance.TryFind("Druid", out ModNPC druid))
-			{
-				if (shop.NpcType == druid.Type)
-					shop.Add(ModContent.ItemType<CloudstalkSeed>(), Condition.DownedEyeOfCthulhu);
-			}
-		}
+		if (ThoriumCompat.Instance.TryFind("Cobbler", out ModNPC cobbler) && shop.NpcType == cobbler.Type)
+			shop.Add(ModContent.ItemType<ExplorerTreadsItem>(), Condition.DownedEyeOfCthulhu);
+
+		if (ThoriumCompat.Instance.TryFind("Druid", out ModNPC druid) && shop.NpcType == druid.Type)
+			shop.Add(ModContent.ItemType<CloudstalkSeed>(), Condition.DownedEyeOfCthulhu);
 	}
 }
 
 internal class ThoriumGlobalTile : GlobalTile
 {
-	private static int? livingLeafCache;
+	private static int LivingLeafCache = -1;
+
+	private static bool TryGetLivingLeaf(out int type)
+	{
+		if (LivingLeafCache != -1)
+		{
+			type = LivingLeafCache;
+			return true;
+		}
+
+		else if (ThoriumCompat.Instance.TryFind("LivingLeaf", out ModItem livingLeaf))
+		{
+			type = LivingLeafCache = livingLeaf.Type;
+			return true;
+		}
+
+		type = 0;
+		return false;
+	}
+
 	public override void KillTile(int i, int j, int type, ref bool fail, ref bool effectOnly, ref bool noItem)
 	{
-		if (ThoriumCompat.Enabled)
-		{
-			if (!livingLeafCache.HasValue && ThoriumCompat.Instance.TryFind("LivingLeaf", out ModItem livingLeaf))
-			{
-				livingLeafCache = livingLeaf.Type;
-			}
+		if (!ThoriumCompat.Enabled || effectOnly || fail)
+			return;
 
-			if (type == ModContent.TileType<LivingBaobabLeaf>() && !fail && !effectOnly)
-			{
-				if (Main.rand.NextBool(3))
-					Item.NewItem(new EntitySource_TileBreak(i, j), new Rectangle(i * 16, j * 16, 16, 16).Center(), livingLeafCache.Value, 1);
-			}
-		}
+		if (type == ModContent.TileType<LivingBaobabLeaf>() && Main.rand.NextBool(3) && TryGetLivingLeaf(out int itemType))
+			Item.NewItem(new EntitySource_TileBreak(i, j), new Vector2(i, j).ToWorldCoordinates(), itemType);
 	}
 }

--- a/Common/ModCompat/ThoriumCompat.cs
+++ b/Common/ModCompat/ThoriumCompat.cs
@@ -1,4 +1,9 @@
-﻿namespace SpiritReforged.Common.ModCompat;
+﻿
+using SpiritReforged.Content.Ocean.Items.JellyfishStaff;
+using SpiritReforged.Content.Vanilla.Food;
+using Terraria.ModLoader;
+
+namespace SpiritReforged.Common.ModCompat;
 
 internal class ThoriumCompat : ModSystem
 {
@@ -10,5 +15,26 @@ internal class ThoriumCompat : ModSystem
 		Instance = null;
 		if (!ModLoader.TryGetMod("ThoriumMod", out Instance))
 			return;
+	}
+}
+
+internal class ThoriumGlobalNPC : GlobalNPC
+{
+	public override void ModifyNPCLoot(NPC npc, NPCLoot npcLoot)
+	{
+		if (ThoriumCompat.Enabled)
+		{
+			if (ThoriumCompat.Instance.TryFind("RagingMinotaur", out ModNPC minotaur))
+			{
+				if (npc.type == minotaur.Type)
+					npcLoot.AddCommon(ItemID.Leather, 1, 5, 10);
+			}
+
+			if (ThoriumCompat.Instance.TryFind("ManofWar", out ModNPC bigJellyfish))
+			{
+				if (npc.type == bigJellyfish.Type)
+					npcLoot.AddCommon(ModContent.ItemType<JellyfishStaff>(), 50);
+			}
+		}
 	}
 }

--- a/Content/Forest/Cloud/Items/CloudstalkSeed.cs
+++ b/Content/Forest/Cloud/Items/CloudstalkSeed.cs
@@ -9,5 +9,7 @@ public class CloudstalkSeed : ModItem
 		Item.DefaultToPlaceableTile(ModContent.TileType<CloudstalkTile>());
 		Item.width = 22;
 		Item.height = 18;
+		Item.shopCustomPrice = 1000;
+		Item.value = 0;
 	}
 }

--- a/Content/Ocean/Items/FishCrate.cs
+++ b/Content/Ocean/Items/FishCrate.cs
@@ -1,5 +1,6 @@
 using SpiritReforged.Common.ItemCommon;
 using SpiritReforged.Common.ItemCommon.FloatingItem;
+using SpiritReforged.Common.ModCompat;
 using Terraria.GameContent.ItemDropRules;
 
 namespace SpiritReforged.Content.Ocean.Items;
@@ -44,6 +45,16 @@ public class FishCrate : FloatingItem
 
 		itemLoot.AddCommon(ItemID.SilverCoin, 3, 40, 91);
 		itemLoot.AddCommon(ItemID.GoldCoin, 7, 2, 5);
+
+		// Thorium Crossmod
+		if (ThoriumCompat.Enabled)
+		{
+			if (ThoriumCompat.Instance.TryFind("HatFish", out ModItem hatfish))
+				itemLoot.AddCommon(hatfish.Type, 25);
+
+			if (ThoriumCompat.Instance.TryFind("SubterraneanBulb", out ModItem anglerBulb))
+				itemLoot.AddCommon(anglerBulb.Type, 100);
+		}
 	}
 }
 

--- a/Content/Ocean/Items/SunkenTreasure.cs
+++ b/Content/Ocean/Items/SunkenTreasure.cs
@@ -5,6 +5,7 @@ using SpiritReforged.Common.TileCommon;
 using Terraria.Audio;
 using Terraria.DataStructures;
 using SpiritReforged.Common.ModCompat.Classic;
+using SpiritReforged.Common.ModCompat;
 
 namespace SpiritReforged.Content.Ocean.Items;
 
@@ -52,6 +53,13 @@ public class SunkenTreasure : FloatingItem
 
 		if (SpiritClassic.Enabled && SpiritClassic.ClassicMod.TryFind("ExplosiveRum", out ModItem rum))
 			itemLoot.AddCommon(rum.Type, 1, 45, 71); //Spirit Classic compatibility; temporary until Explosive Rum is added to Reforged
+
+		//Thorium Crossmod
+		if (ThoriumCompat.Enabled)
+		{
+			if (ThoriumCompat.Instance.TryFind("Opal", out ModItem opal) && ThoriumCompat.Instance.TryFind("Aquamarine", out ModItem aquamarine))
+				itemLoot.Add(DropRules.LootPoolDrop.SameStack(5, 7, 1, 4, 1, opal.Type, aquamarine.Type));
+		}
 
 		var goldCoins = ItemDropRule.Common(ItemID.GoldCoin, 2, 1, 4);
 		goldCoins.OnFailedRoll(ItemDropRule.Common(ItemID.Cobweb, 1, 8, 13));


### PR DESCRIPTION
NOTE: Waiting on Diver's permission before pushing to master pls 

A patch that introduces deliberate crossmod compatibility between Spirit and Thorium, as follows:
- Add Hat Fish and Subterranean Bulb to Packing Crate pool
- Make Man O’ War drop Jellyfish Staff
- Make Raging Minotaurs drop Leather
- If Eye of Cthulhu is defeated, Cobbler sells Explorer’s Treads
- Druid sells Cloudstalk Seeds after Eye of Cthulhu is defeated
- Baobab Leaves drop Living Leaves
- Sunken Treasure has Aquamarine and Opal in its loot pools