### PR TITLE
Minion Tweaks/Buffs

### DIFF
--- a/Content/Forest/ButterflyStaff/ButterflyMinion.cs
+++ b/Content/Forest/ButterflyStaff/ButterflyMinion.cs
@@ -91,7 +91,7 @@ public class ButterflyMinion : BaseMinion
 	{
 		AiState = Moving;
 
-		if (Math.Abs(MathHelper.WrapAngle(Projectile.velocity.ToRotation() - Projectile.AngleTo(target.Center))) < MathHelper.PiOver4) // If close enough in desired angle, accelerate and home accurately
+		if (Math.Abs(MathHelper.WrapAngle(Projectile.velocity.ToRotation() - Projectile.AngleTo(target.Center))) < MathHelper.PiOver2) // If close enough in desired angle, accelerate and home accurately
 			Projectile.velocity = Vector2.Lerp(Projectile.velocity, Projectile.DirectionTo(target.Center) * 18, 0.1f);
 		else // If too much of an angle, circle around
 		{

--- a/Content/Jungle/Toucane/ToucanMinion.cs
+++ b/Content/Jungle/Toucane/ToucanMinion.cs
@@ -217,10 +217,10 @@ public class ToucanMinion : BaseMinion
 	{
 		const int FeatherMinRange = 200;
 		const int FeatherMaxRange = 600;
-		const int FeatherShootTime = 25;
+		const int FeatherShootTime = 18;
 		const int FeatherShots = 3;
 		const float GlideStartVelocity = 9;
-		const float GlideMaxVelocity = 13;
+		const float GlideMaxVelocity = 14;
 		const int GlideTime = 45;
 
 		Projectile.tileCollide = AiState is STATE_GLIDING or STATE_FEATHERSHOOT;
@@ -279,7 +279,7 @@ public class ToucanMinion : BaseMinion
 					if (Main.netMode != NetmodeID.Server)
 						SoundEngine.PlaySound(new SoundStyle("SpiritReforged/Assets/SFX/Projectile/SmallProjectileWoosh_1") with { PitchVariance = 0.3f, Volume = 1.25f }, Projectile.Center);
 
-					Projectile.NewProjectileDirect(Projectile.GetSource_FromAI(), Projectile.Center, Projectile.DirectionTo(target.Center) * 8, ModContent.ProjectileType<ToucanFeather>(), (int)(Projectile.damage * 0.8), Projectile.knockBack, Projectile.owner);
+					Projectile.NewProjectileDirect(Projectile.GetSource_FromAI(), Projectile.Center, Projectile.DirectionTo(target.Center) * 8, ModContent.ProjectileType<ToucanFeather>(), Projectile.damage, Projectile.knockBack, Projectile.owner);
 					for (int j = 0; j < 6; j++)
 					{
 						var dust = Dust.NewDustPerfect(Projectile.Center, 90, Projectile.DirectionTo(target.Center).RotatedByRandom(MathHelper.Pi / 3) * Main.rand.NextFloat(1f, 2f), 100, default, Main.rand.NextFloat(0.15f, 0.3f));

--- a/Content/Ocean/Items/JellyfishStaff/JellyfishBolt.cs
+++ b/Content/Ocean/Items/JellyfishStaff/JellyfishBolt.cs
@@ -16,7 +16,7 @@ public class JellyfishBolt : ModProjectile
 		set => Projectile.ai[0] = value ? 1 : 0;
 	}
 
-	public static int MAX_CHAIN_DISTANCE => (int)(JellyfishMinion.SHOOT_RANGE * 0.66f);
+	public static int MAX_CHAIN_DISTANCE => (int)(JellyfishMinion.SHOOT_RANGE * 0.75f);
 	public static int HITSCAN_STEP { get; set; } = 5;
 
 	public Vector2 startPos;
@@ -29,7 +29,7 @@ public class JellyfishBolt : ModProjectile
 	{
 		Projectile.friendly = true;
 		Projectile.hostile = false;
-		Projectile.penetrate = 3; //Number of chains between enemies
+		Projectile.penetrate = 4; //Number of chains between enemies
 		Projectile.timeLeft = JellyfishMinion.SHOOT_RANGE / HITSCAN_STEP;
 		Projectile.height = 4;
 		Projectile.width = 4;
@@ -67,7 +67,7 @@ public class JellyfishBolt : ModProjectile
 				Projectile.velocity = Projectile.DirectionTo(newTarget.Center) * HITSCAN_STEP;
 				startPos = target.Center;
 				Projectile.netUpdate = true;
-				Projectile.damage = (int)(Projectile.damage * 0.8f);
+				Projectile.damage = (int)(Projectile.damage * 0.9f);
 			}
 			else
 				Projectile.penetrate = 0;
@@ -77,7 +77,6 @@ public class JellyfishBolt : ModProjectile
 	/// <summary> Can be shared between all clients in multiplayer for synced hit effects. </summary>
 	public void SharedOnHitNPC(NPC target)
 	{
-		SoundEngine.PlaySound(new SoundStyle("SpiritReforged/Assets/SFX/Projectile/ElectricSting") with { PitchVariance = 0.5f, Pitch = .65f, Volume = 0.8f, MaxInstances = 3 }, Projectile.Center);
 		ParticleHandler.SpawnParticle(new LightningParticle(startPos, target.Center, ParticleColor, 30, 30f));
 
 		HitEffects(target.Center);

--- a/Content/Ocean/Items/JellyfishStaff/JellyfishMinion.cs
+++ b/Content/Ocean/Items/JellyfishStaff/JellyfishMinion.cs
@@ -31,9 +31,9 @@ public class JellyfishMinion : BaseMinion
 	private const int AISTATE_SHOOT = 5; //when near target, hover in place and shoot lightning
 
 	//Constants used in drawing methods and for the ai pattern
-	private const int SHOOTTIME = 60; //Time between shots
+	private const int SHOOTTIME = 45; //Time between shots
 	private const int DASHTIME = 30; //Time the dash takes
-	private const int AIMTIME = 60; //Time it takes to aim the dash
+	private const int AIMTIME = 50; //Time it takes to aim the dash
 	private const int BOUNCETIME = 90; //General time between bounces
 	private const int RISETIME = 20; //Time it takes to rise upwards after the dash
 
@@ -214,8 +214,8 @@ public class JellyfishMinion : BaseMinion
 				if (AiTimer % SHOOTTIME == 0)
 				{
 					Color particleColor = IsPink ? new Color(255, 161, 225) : new Color(156, 255, 245);
-					SoundEngine.PlaySound(new SoundStyle("SpiritReforged/Assets/SFX/Projectile/ElectricZap") with { PitchVariance = 0.3f, Pitch = 0.3f, Volume = .55f, MaxInstances = 3 }, Projectile.Center);
-					SoundEngine.PlaySound(new SoundStyle("SpiritReforged/Assets/SFX/Projectile/ElectricZap2") with { Pitch = -.45f, Volume = .35f, MaxInstances = 3 }, Projectile.Center);
+					SoundEngine.PlaySound(new SoundStyle("SpiritReforged/Assets/SFX/Projectile/ElectricZap") with { Pitch = -.55f, Volume = .55f, MaxInstances = 3 }, Projectile.Center);
+					SoundEngine.PlaySound(new SoundStyle("SpiritReforged/Assets/SFX/Projectile/ElectricZap2") with { Pitch = -.65f, Volume = .35f, MaxInstances = 3 }, Projectile.Center);
 					ParticleHandler.SpawnParticle(new TexturedPulseCircle(
 						Projectile.Center + aimDirection * 10,
 						Color.White.Additive(),

--- a/Content/Ocean/Items/JellyfishStaff/JellyfishStaff.cs
+++ b/Content/Ocean/Items/JellyfishStaff/JellyfishStaff.cs
@@ -21,7 +21,7 @@ public class JellyfishStaff : ModItem
 		Item.value = Item.sellPrice(0, 2, 0, 0);
 		Item.rare = ItemRarityID.Blue;
 		Item.mana = 10;
-		Item.damage = 11;
+		Item.damage = 12;
 		Item.knockBack = 2.5f;
 		Item.useStyle = ItemUseStyleID.Swing;
 		Item.useTime = 30;


### PR DESCRIPTION
Jellyfish Staff:
- Reduced pitch on SFX
- Increased the range of the chain lightning by 9%, number of chain targets by 1
- Increased damage by 1
- Reduced time between dashes from 1 second to 2/3 of a second
- Reduced the damage falloff per chained enemy from .8 of the original damage to .9 

Butterfly Staff:
- Made the butterfly more aggressive and more likely to quickly attack foes instead of spinning around them

Toucane:
- Increased maximum dash speed slightly
- Increased damage of feathers from .8 minion damage to just whatever the damage is
- increased the firing speed of feathers, thereby increasing the overall attack speed