### PR TITLE
Make Classic Raw Fish Unobtainable

### DIFF
--- a/Common/ModCompat/Classic/ModifyNPCData.cs
+++ b/Common/ModCompat/Classic/ModifyNPCData.cs
@@ -8,11 +8,11 @@ internal class ModifyNPCData : GlobalNPC
 {
 	public override void ModifyNPCLoot(NPC npc, NPCLoot npcLoot)
 	{
-		if (npc.type == NPCID.PirateShip && SpiritClassic.ClassicMod.TryFind("PirateKey", out ModItem key))
-			npcLoot.RemoveWhere(rule => rule is CommonDrop drop && drop.itemId == key.Type);
-
-		if (SpiritClassic.ClassicMod.TryFind("RawFish", out ModItem fish))
-			npcLoot.RemoveWhere(rule => rule is CommonDrop drop && drop.itemId == fish.Type);
+		foreach (var rule in npcLoot.Get())
+		{
+			if (rule is CommonDrop drop && SpiritClassic.ClassicToReforged.TryGetValue(drop.itemId, out int reforged))
+				drop.itemId = reforged;
+		}
 	}
 
 	public override void ModifyShop(NPCShop shop)

--- a/Common/ModCompat/Classic/ModifyNPCData.cs
+++ b/Common/ModCompat/Classic/ModifyNPCData.cs
@@ -10,6 +10,9 @@ internal class ModifyNPCData : GlobalNPC
 	{
 		if (npc.type == NPCID.PirateShip && SpiritClassic.ClassicMod.TryFind("PirateKey", out ModItem key))
 			npcLoot.RemoveWhere(rule => rule is CommonDrop drop && drop.itemId == key.Type);
+
+		if (SpiritClassic.ClassicMod.TryFind("RawFish", out ModItem fish))
+			npcLoot.RemoveWhere(rule => rule is CommonDrop drop && drop.itemId == fish.Type);
 	}
 
 	public override void ModifyShop(NPCShop shop)

--- a/Content/Ocean/Items/PirateKey.cs
+++ b/Content/Ocean/Items/PirateKey.cs
@@ -1,19 +1,10 @@
 ﻿using SpiritReforged.Common.ModCompat.Classic;
-using SpiritReforged.Common.NPCCommon;
-using Terraria.GameContent.ItemDropRules;
 
 namespace SpiritReforged.Content.Ocean.Items;
 
 public class PirateKey : ModItem
 {
 	public override bool IsLoadingEnabled(Mod mod) => SpiritClassic.Enabled;
-
-	public override void SetStaticDefaults()
-	{
-		Item.ResearchUnlockCount = 1;
-		NPCLootDatabase.AddLoot(new(NPCLootDatabase.MatchId(NPCID.PirateShip), ItemDropRule.Common(Type)));
-	}
-
 	public override void SetDefaults()
 	{
 		Item.width = 14;

--- a/Content/Vanilla/Food/RawFish.cs
+++ b/Content/Vanilla/Food/RawFish.cs
@@ -1,9 +1,7 @@
 using SpiritReforged.Common.ItemCommon;
-using SpiritReforged.Common.ModCompat.Classic;
 
 namespace SpiritReforged.Content.Vanilla.Food;
 
-[FromClassic("RawFish")]
 public class RawFish : FoodItem
 {
 	internal override Point Size => new(34, 22);

--- a/Content/Vanilla/Food/RawFish.cs
+++ b/Content/Vanilla/Food/RawFish.cs
@@ -1,7 +1,9 @@
 using SpiritReforged.Common.ItemCommon;
+using SpiritReforged.Common.ModCompat.Classic;
 
 namespace SpiritReforged.Content.Vanilla.Food;
 
+[FromClassic("RawFish")]
 public class RawFish : FoodItem
 {
 	internal override Point Size => new(34, 22);


### PR DESCRIPTION
- As per a compat report in main, Spirit Classic enemies no longer drop Raw Fish, and Classic Raw Fish is now shimmerable