### PR TITLE
Pot Tweaks

### DIFF
--- a/Common/TileCommon/PresetTiles/PotTile.cs
+++ b/Common/TileCommon/PresetTiles/PotTile.cs
@@ -41,7 +41,7 @@ public abstract class PotTile : ModTile, IRecordTile, IAutoloadRubble
 	}
 
 	/// <summary> <inheritdoc cref="ModType.SetStaticDefaults"/><para/>
-	/// Automatically sets common pot data by type. See <see cref="AddObjectData"/>.
+	/// Automatically sets common pot data by type. See <see cref="AddObjectData"/> and <see cref="=AddMapData">
 	/// </summary>
 	public override void SetStaticDefaults()
 	{
@@ -50,12 +50,14 @@ public abstract class PotTile : ModTile, IRecordTile, IAutoloadRubble
 		Main.tileCut[Type] = !Autoloader.IsRubble(Type);
 		Main.tileFrameImportant[Type] = true;
 		Main.tileSpelunker[Type] = true;
-
-		AddMapEntry(new Color(100, 90, 35), Language.GetText("MapObject.Pot"));
 		DustType = -1;
 
 		AddObjectData();
+		AddMapData();
 	}
+
+	/// <summary> Adds map data for the pot. Defaults to vanilla pot map entry and color.
+	public virtual void AddMapData() => AddMapEntry(new Color(146, 76, 77), Language.GetText("MapObject.Pot"));
 
 	/// <summary> Adds object data for this pot. By default, assumes <see cref="TileObjectData.Style2x2"/> with <see cref="TileObjectData.StyleWrapLimit"/> of 3. </summary>
 	public virtual void AddObjectData()

--- a/Content/Underground/Tiles/AetherShipment.cs
+++ b/Content/Underground/Tiles/AetherShipment.cs
@@ -24,6 +24,7 @@ public class AetherShipment : PotTile, ISwayTile, ILootTile, ICutAttempt
 	public override void AddObjectData()
 	{
 		Main.tileCut[Type] = !Autoloader.IsRubble(Type);
+		Main.tileOreFinderPriority[Type] = 575;
 
 		TileObjectData.newTile.CopyFrom(TileObjectData.Style2x2);
 		TileObjectData.newTile.Origin = new(0, 1);

--- a/Content/Underground/Tiles/AetherShipment.cs
+++ b/Content/Underground/Tiles/AetherShipment.cs
@@ -38,6 +38,8 @@ public class AetherShipment : PotTile, ISwayTile, ILootTile, ICutAttempt
 		DustType = DustID.ShimmerTorch;
 	}
 
+	public override void AddMapData() => AddMapEntry(new Color(225, 174, 252), CreateMapEntryName());
+
 	public override void NearbyEffects(int i, int j, bool closer)
 	{
 		const int distance = 200;

--- a/Content/Underground/Tiles/BiomePots.cs
+++ b/Content/Underground/Tiles/BiomePots.cs
@@ -9,6 +9,7 @@ using SpiritReforged.Content.Underground.Pottery;
 using Terraria.Audio;
 using Terraria.DataStructures;
 using Terraria.GameContent.ItemDropRules;
+using static SpiritReforged.Content.Underground.Tiles.BiomePots;
 
 namespace SpiritReforged.Content.Underground.Tiles;
 
@@ -62,6 +63,30 @@ public class BiomePots : PotTile, ILootTile
 		Style.Hell => 2.5f,
 		_ => 1.25f
 	};
+
+	/// <summary> Gets the map
+	private static Color GetColor(Style style) => style switch
+	{
+		Style.Cavern => new Color(150, 150, 150),
+		Style.Gold => Color.Gold,
+		Style.Ice => new Color(90, 139, 140),
+		Style.Desert => new Color(226, 122, 47),
+		Style.Jungle => new Color(192, 136, 70),
+		Style.Dungeon => new Color(203, 185, 151),
+		Style.Corruption => new Color(148, 159, 67),
+		Style.Crimson => new Color(198, 87, 93),
+		Style.Marble => new Color(201, 183, 149),
+		Style.Hell => new Color(73, 56, 41),
+		Style.Mushroom => new Color(172, 155, 110),
+		_ => new Color(146, 76, 77) // default color
+	};
+
+	public override void AddMapData()
+	{
+		var style = GetStyle(Type);
+		Color color = GetColor(style);
+		AddMapEntry(color, Language.GetText($"MapObject.Pot"));
+	}
 
 	public override void NearbyEffects(int i, int j, bool closer)
 	{

--- a/Content/Underground/Tiles/ScryingPot.cs
+++ b/Content/Underground/Tiles/ScryingPot.cs
@@ -82,6 +82,8 @@ public class ScryingPot : PotTile
 			Gore.NewGore(new EntitySource_TileBreak(i, j), new Vector2(i, j) * 16, Vector2.Zero, x);
 	}
 
+	public LootTable AddLoot(int objectStyle) => ModContent.GetInstance<Pots>().AddLoot(objectStyle);
+
 	public override bool PreDraw(int i, int j, SpriteBatch spriteBatch)
 	{
 		if (TileObjectData.IsTopLeft(i, j))

--- a/Content/Underground/Tiles/ScryingPot.cs
+++ b/Content/Underground/Tiles/ScryingPot.cs
@@ -40,6 +40,8 @@ public class ScryingPot : PotTile
 		DustType = DustID.Pot;
 	}
 
+	public override void AddMapData() => AddMapEntry(new Color(146, 76, 77), CreateMapEntryName());
+
 	public override bool KillSound(int i, int j, bool fail)
 	{
 		if (!fail)

--- a/Content/Underground/Tiles/ScryingPot.cs
+++ b/Content/Underground/Tiles/ScryingPot.cs
@@ -1,4 +1,5 @@
 using RubbleAutoloader;
+using SpiritReforged.Common.ItemCommon;
 using SpiritReforged.Common.Particle;
 using SpiritReforged.Common.TileCommon;
 using SpiritReforged.Common.TileCommon.PresetTiles;
@@ -10,7 +11,7 @@ using Terraria.DataStructures;
 
 namespace SpiritReforged.Content.Underground.Tiles;
 
-public class ScryingPot : PotTile
+public class ScryingPot : PotTile, ILootTile
 {
 	public override Dictionary<string, int[]> TileStyles => new() { { string.Empty, [0] } };
 
@@ -78,6 +79,17 @@ public class ScryingPot : PotTile
 			ParticleHandler.SpawnParticle(new GlowParticle(newSpawn, spawn.DirectionTo(newSpawn) * speed, Color.White, .2f, time));
 		}
 
+		if (Main.netMode != NetmodeID.MultiplayerClient)
+		{
+			ItemMethods.SplitCoins(Main.rand.Next(6000, 9000), delegate (int type, int stack)
+			{
+				Item.NewItem(new EntitySource_TileBreak(i, j), spawn, new Item(type, stack), noGrabDelay: true);
+			});
+
+			var p = Main.player[Player.FindClosest(spawn, 0, 0)];
+			AddLoot(TileObjectData.GetTileStyle(Main.tile[i, j])).Resolve(new Rectangle((int)spawn.X - 16, (int)spawn.Y - 16, 32, 32), p);
+		}
+
 		for (int x = 51; x < 54; x++)
 			Gore.NewGore(new EntitySource_TileBreak(i, j), new Vector2(i, j) * 16, Vector2.Zero, x);
 	}
@@ -86,9 +98,6 @@ public class ScryingPot : PotTile
 	{
 		var loot = new LootTable();
 		loot.AddOneFromOptions(1, ItemID.NightOwlPotion, ItemID.ShinePotion, ItemID.BiomeSightPotion, ItemID.TrapsightPotion, ItemID.HunterPotion, ItemID.SpelunkerPotion);
-
-		loot.AddCommon(ItemID.SilverCoin, 1, 15, 50);
-
 		return loot;
 	}
 	public override bool PreDraw(int i, int j, SpriteBatch spriteBatch)

--- a/Content/Underground/Tiles/ScryingPot.cs
+++ b/Content/Underground/Tiles/ScryingPot.cs
@@ -82,8 +82,15 @@ public class ScryingPot : PotTile
 			Gore.NewGore(new EntitySource_TileBreak(i, j), new Vector2(i, j) * 16, Vector2.Zero, x);
 	}
 
-	public LootTable AddLoot(int objectStyle) => ModContent.GetInstance<Pots>().AddLoot(objectStyle);
+	public LootTable AddLoot(int objectStyle)
+	{
+		var loot = new LootTable();
+		loot.AddOneFromOptions(1, ItemID.NightOwlPotion, ItemID.ShinePotion, ItemID.BiomeSightPotion, ItemID.TrapsightPotion, ItemID.HunterPotion, ItemID.SpelunkerPotion);
 
+		loot.AddCommon(ItemID.SilverCoin, 1, 15, 50);
+
+		return loot;
+	}
 	public override bool PreDraw(int i, int j, SpriteBatch spriteBatch)
 	{
 		if (TileObjectData.IsTopLeft(i, j))

--- a/Content/Underground/Tiles/ScryingPot.cs
+++ b/Content/Underground/Tiles/ScryingPot.cs
@@ -24,6 +24,8 @@ public class ScryingPot : PotTile
 	{
 		const int row = 1;
 
+		Main.tileOreFinderPriority[Type] = 575;
+
 		TileObjectData.newTile.CopyFrom(TileObjectData.Style2x2);
 		TileObjectData.newTile.Origin = new(0, 1);
 		TileObjectData.newTile.AnchorBottom = new AnchorData(AnchorType.SolidTile | AnchorType.SolidWithTop, TileObjectData.newTile.Width, 0);

--- a/Content/Underground/Tiles/SilverFoodPlatter.cs
+++ b/Content/Underground/Tiles/SilverFoodPlatter.cs
@@ -16,6 +16,7 @@ public class SilverFoodPlatter : SingleSlotTile<PlatterSlot>, IAutoloadTileItem
 		Main.tileMergeDirt[Type] = false;
 		Main.tileBlockLight[Type] = false;
 		Main.tileFrameImportant[Type] = true;
+		Main.tileOreFinderPriority[Type] = 575;
 
 		TileObjectData.newTile.CopyFrom(TileObjectData.Style2x1);
 		TileObjectData.newTile.DrawYOffset = 2;

--- a/Content/Underground/Tiles/SilverFoodPlatter.cs
+++ b/Content/Underground/Tiles/SilverFoodPlatter.cs
@@ -16,7 +16,6 @@ public class SilverFoodPlatter : SingleSlotTile<PlatterSlot>, IAutoloadTileItem
 		Main.tileMergeDirt[Type] = false;
 		Main.tileBlockLight[Type] = false;
 		Main.tileFrameImportant[Type] = true;
-		Main.tileOreFinderPriority[Type] = 575;
 
 		TileObjectData.newTile.CopyFrom(TileObjectData.Style2x1);
 		TileObjectData.newTile.DrawYOffset = 2;

--- a/Content/Underground/Tiles/SilverPlatters.cs
+++ b/Content/Underground/Tiles/SilverPlatters.cs
@@ -20,6 +20,10 @@ public class SilverPlatters : PotTile, ILootTile
 		RecordHandler.Records.Add(new TileRecord(group.name, type, group.styles).AddDescription(desc).AddRating(3));
 	}
 
+	public override void AddObjectData() => Main.tileOreFinderPriority[Type] = 575;
+
+	public override void AddMapData() => AddMapEntry(Color.Silver, CreateMapEntryName());
+
 	public override void NearbyEffects(int i, int j, bool closer)
 	{
 		const int distance = 200;

--- a/Content/Underground/Tiles/SilverPlatters.cs
+++ b/Content/Underground/Tiles/SilverPlatters.cs
@@ -20,7 +20,11 @@ public class SilverPlatters : PotTile, ILootTile
 		RecordHandler.Records.Add(new TileRecord(group.name, type, group.styles).AddDescription(desc).AddRating(3));
 	}
 
-	public override void AddObjectData() => Main.tileOreFinderPriority[Type] = 575;
+	public override void AddObjectData()
+	{
+		Main.tileOreFinderPriority[Type] = 575;
+		base.AddObjectData();
+	}
 
 	public override void AddMapData() => AddMapEntry(Color.Silver, CreateMapEntryName());
 

--- a/Content/Underground/Tiles/StuffedPots.cs
+++ b/Content/Underground/Tiles/StuffedPots.cs
@@ -19,6 +19,8 @@ public class StuffedPots : PotTile
 
 	public override void AddObjectData() => Main.tileOreFinderPriority[Type] = 575;
 
+	public override void AddMapData() => AddMapEntry(new Color(146, 76, 77), CreateMapEntryName());
+
 	public override bool KillSound(int i, int j, bool fail)
 	{
 		if (fail || Autoloader.IsRubble(Type))

--- a/Content/Underground/Tiles/StuffedPots.cs
+++ b/Content/Underground/Tiles/StuffedPots.cs
@@ -17,7 +17,11 @@ public class StuffedPots : PotTile
 		RecordHandler.Records.Add(new TileRecord(group.name, type, group.styles).AddDescription(desc).AddRating(5));
 	}
 
-	public override void AddObjectData() => Main.tileOreFinderPriority[Type] = 575;
+	public override void AddObjectData()
+	{
+		Main.tileOreFinderPriority[Type] = 575;
+		base.AddObjectData();
+	}
 
 	public override void AddMapData() => AddMapEntry(new Color(146, 76, 77), CreateMapEntryName());
 

--- a/Content/Underground/Tiles/StuffedPots.cs
+++ b/Content/Underground/Tiles/StuffedPots.cs
@@ -17,6 +17,8 @@ public class StuffedPots : PotTile
 		RecordHandler.Records.Add(new TileRecord(group.name, type, group.styles).AddDescription(desc).AddRating(5));
 	}
 
+	public override void AddObjectData() => Main.tileOreFinderPriority[Type] = 575;
+
 	public override bool KillSound(int i, int j, bool fail)
 	{
 		if (fail || Autoloader.IsRubble(Type))

--- a/Content/Underground/Tiles/WormPot.cs
+++ b/Content/Underground/Tiles/WormPot.cs
@@ -26,6 +26,7 @@ public class WormPot : PotTile, ISwayTile, ILootTile, ICutAttempt
 	public override void AddObjectData()
 	{
 		Main.tileCut[Type] = !Autoloader.IsRubble(Type);
+		Main.tileOreFinderPriority[Type] = 575;
 
 		TileObjectData.newTile.CopyFrom(TileObjectData.Style2x2);
 		TileObjectData.newTile.Origin = new(0, 1);

--- a/Content/Underground/Tiles/WormPot.cs
+++ b/Content/Underground/Tiles/WormPot.cs
@@ -40,6 +40,8 @@ public class WormPot : PotTile, ISwayTile, ILootTile, ICutAttempt
 		DustType = DustID.Plantera_Pink;
 	}
 
+	public override void AddMapData() => AddMapEntry(Color.MediumVioletRed, CreateMapEntryName());
+
 	public override void NumDust(int i, int j, bool fail, ref int num) => num = fail ? 1 : 3;
 	public override void KillTile(int i, int j, ref bool fail, ref bool effectOnly, ref bool noItem)
 	{

--- a/Localization/en-US/Mods.SpiritReforged.Items.hjson
+++ b/Localization/en-US/Mods.SpiritReforged.Items.hjson
@@ -1609,18 +1609,10 @@ BombCannon: {
 
 RadonMossBobberItem: {
 	DisplayName: Radon Moss Fishing Bobber
-	Tooltip:
-		'''
-		Increases fishing power by 10
-		Your bobber now glows
-		'''
+	Tooltip: "{$ItemTooltip.FishingBobberGlowingArgon}"
 }
 
 OganessonMossBobberItem: {
 	DisplayName: Oganesson Moss Fishing Bobber
-	Tooltip:
-		'''
-		Increases fishing power by 10
-		Your bobber now glows
-		'''
+	Tooltip: "{$ItemTooltip.FishingBobberGlowingArgon}"
 }

--- a/Localization/en-US/Mods.SpiritReforged.Items.hjson
+++ b/Localization/en-US/Mods.SpiritReforged.Items.hjson
@@ -1609,16 +1609,16 @@ BombCannon: {
 
 RadonMossBobberItem: {
 	DisplayName: Radon Moss Fishing Bobber
-	Tooltip: 
+	Tooltip:
 		'''
 		Increases fishing power by 10
 		Your bobber now glows
-		'''			 
+		'''
 }
 
 OganessonMossBobberItem: {
 	DisplayName: Oganesson Moss Fishing Bobber
-	Tooltip: 		
+	Tooltip:
 		'''
 		Increases fishing power by 10
 		Your bobber now glows

--- a/Localization/en-US/Mods.SpiritReforged.Tiles.hjson
+++ b/Localization/en-US/Mods.SpiritReforged.Tiles.hjson
@@ -35,3 +35,13 @@ TermiteJar_Tile.MapEntry: Termite Jar
 GarInAJarTile.MapEntry: Gar In A Jar
 KillieFishbowlTile.MapEntry: Killie Fishbowl
 OreCarts.MapEntry: Minecart
+AetherShipment.MapEntry: Aether Shipment
+ScryingPot.MapEntry: Scrying Pot
+SilverPlatters.MapEntry: Silver Platter
+StuffedPots.MapEntry: Stuffed Pot
+WormPot.MapEntry: Worm Pot
+AetherShipmentRubble.MapEntry: Aether Shipment 
+ScryingPotRubble.MapEntry: Scrying Pot 
+SilverPlattersRubble.MapEntry: Silver Platter
+StuffedPotsRubble.MapEntry: Stuffed Pot
+WormPotRubble.MapEntry: Worm Pot

--- a/Localization/en-US/Mods.SpiritReforged.Tiles.hjson
+++ b/Localization/en-US/Mods.SpiritReforged.Tiles.hjson
@@ -35,13 +35,13 @@ TermiteJar_Tile.MapEntry: Termite Jar
 GarInAJarTile.MapEntry: Gar In A Jar
 KillieFishbowlTile.MapEntry: Killie Fishbowl
 OreCarts.MapEntry: Minecart
-AetherShipment.MapEntry: Aether Shipment
-ScryingPot.MapEntry: Scrying Pot
-SilverPlatters.MapEntry: Silver Platter
-StuffedPots.MapEntry: Stuffed Pot
-WormPot.MapEntry: Worm Pot
-AetherShipmentRubble.MapEntry: Aether Shipment 
-ScryingPotRubble.MapEntry: Scrying Pot 
-SilverPlattersRubble.MapEntry: Silver Platter
-StuffedPotsRubble.MapEntry: Stuffed Pot
-WormPotRubble.MapEntry: Worm Pot
+AetherShipment.MapEntry: "{$AetherShipmentItem.DisplayName}"
+ScryingPot.MapEntry: "{$ScryingPotItem.DisplayName}"
+SilverPlatters.MapEntry: "{$SilverPlattersItem.DisplayName}"
+StuffedPots.MapEntry: "{$StuffedPotsItem.DisplayName}"
+WormPot.MapEntry: "{$WormPotItem.DisplayName}"
+AetherShipmentRubble.MapEntry: "{$AetherShipmentItem.DisplayName}"
+ScryingPotRubble.MapEntry: "{$ScryingPotItem.DisplayName}"
+SilverPlattersRubble.MapEntry: "{$SilverPlattersItem.DisplayName}"
+StuffedPotsRubble.MapEntry: "{$StuffedPotsItem.DisplayName}"
+WormPotRubble.MapEntry: "{$WormPotItem.DisplayName}"

--- a/Localization/pt-BR/Mods.SpiritReforged.Items.hjson
+++ b/Localization/pt-BR/Mods.SpiritReforged.Items.hjson
@@ -1609,18 +1609,10 @@ BombCannon: {
 
 RadonMossBobberItem: {
 	// DisplayName: Radon Moss Fishing Bobber
-	/* Tooltip:
-		'''
-		Increases fishing power by 10
-		Your bobber now glows
-		''' */
+	// Tooltip: "{$ItemTooltip.FishingBobberGlowingArgon}"
 }
 
 OganessonMossBobberItem: {
 	// DisplayName: Oganesson Moss Fishing Bobber
-	/* Tooltip:
-		'''
-		Increases fishing power by 10
-		Your bobber now glows
-		''' */
+	// Tooltip: "{$ItemTooltip.FishingBobberGlowingArgon}"
 }

--- a/Localization/pt-BR/Mods.SpiritReforged.Items.hjson
+++ b/Localization/pt-BR/Mods.SpiritReforged.Items.hjson
@@ -1608,11 +1608,19 @@ BombCannon: {
 }
 
 RadonMossBobberItem: {
-	// DisplayName: Radon Moss Bobber Item
-	// Tooltip: ""
+	// DisplayName: Radon Moss Fishing Bobber
+	/* Tooltip:
+		'''
+		Increases fishing power by 10
+		Your bobber now glows
+		''' */
 }
 
 OganessonMossBobberItem: {
-	// DisplayName: Oganesson Moss Bobber Item
-	// Tooltip: ""
+	// DisplayName: Oganesson Moss Fishing Bobber
+	/* Tooltip:
+		'''
+		Increases fishing power by 10
+		Your bobber now glows
+		''' */
 }

--- a/Localization/pt-BR/Mods.SpiritReforged.Tiles.hjson
+++ b/Localization/pt-BR/Mods.SpiritReforged.Tiles.hjson
@@ -35,3 +35,13 @@ TermiteJar_Tile.MapEntry: Pote de Cupim
 GarInAJarTile.MapEntry: Gar em um Jarro
 KillieFishbowlTile.MapEntry: Aquário de Killie
 // OreCarts.MapEntry: Minecart
+// AetherShipment.MapEntry: Aether Shipment
+// ScryingPot.MapEntry: Scrying Pot
+// SilverPlatters.MapEntry: Silver Platters
+// StuffedPots.MapEntry: Stuffed Pots
+// WormPot.MapEntry: Worm Pot
+// AetherShipmentRubble.MapEntry: Aether Shipment Rubble
+// ScryingPotRubble.MapEntry: Scrying Pot Rubble
+// SilverPlattersRubble.MapEntry: Silver Platters Rubble
+// StuffedPotsRubble.MapEntry: Stuffed Pots Rubble
+// WormPotRubble.MapEntry: Worm Pot Rubble

--- a/Localization/pt-BR/Mods.SpiritReforged.Tiles.hjson
+++ b/Localization/pt-BR/Mods.SpiritReforged.Tiles.hjson
@@ -35,13 +35,13 @@ TermiteJar_Tile.MapEntry: Pote de Cupim
 GarInAJarTile.MapEntry: Gar em um Jarro
 KillieFishbowlTile.MapEntry: Aquário de Killie
 // OreCarts.MapEntry: Minecart
-// AetherShipment.MapEntry: Aether Shipment
-// ScryingPot.MapEntry: Scrying Pot
-// SilverPlatters.MapEntry: Silver Platters
-// StuffedPots.MapEntry: Stuffed Pots
-// WormPot.MapEntry: Worm Pot
-// AetherShipmentRubble.MapEntry: Aether Shipment Rubble
-// ScryingPotRubble.MapEntry: Scrying Pot Rubble
-// SilverPlattersRubble.MapEntry: Silver Platters Rubble
-// StuffedPotsRubble.MapEntry: Stuffed Pots Rubble
-// WormPotRubble.MapEntry: Worm Pot Rubble
+// AetherShipment.MapEntry: "{$AetherShipmentItem.DisplayName}"
+// ScryingPot.MapEntry: "{$ScryingPotItem.DisplayName}"
+// SilverPlatters.MapEntry: "{$SilverPlattersItem.DisplayName}"
+// StuffedPots.MapEntry: "{$StuffedPotsItem.DisplayName}"
+// WormPot.MapEntry: "{$WormPotItem.DisplayName}"
+// AetherShipmentRubble.MapEntry: "{$AetherShipmentItem.DisplayName}"
+// ScryingPotRubble.MapEntry: "{$ScryingPotItem.DisplayName}"
+// SilverPlattersRubble.MapEntry: "{$SilverPlattersItem.DisplayName}"
+// StuffedPotsRubble.MapEntry: "{$StuffedPotsItem.DisplayName}"
+// WormPotRubble.MapEntry: "{$WormPotItem.DisplayName}"

--- a/Localization/ru-RU/Mods.SpiritReforged.Items.hjson
+++ b/Localization/ru-RU/Mods.SpiritReforged.Items.hjson
@@ -1601,18 +1601,10 @@ BombCannon: {
 
 RadonMossBobberItem: {
 	// DisplayName: Radon Moss Fishing Bobber
-	/* Tooltip:
-		'''
-		Increases fishing power by 10
-		Your bobber now glows
-		''' */
+	// Tooltip: "{$ItemTooltip.FishingBobberGlowingArgon}"
 }
 
 OganessonMossBobberItem: {
 	// DisplayName: Oganesson Moss Fishing Bobber
-	/* Tooltip:
-		'''
-		Increases fishing power by 10
-		Your bobber now glows
-		''' */
+	// Tooltip: "{$ItemTooltip.FishingBobberGlowingArgon}"
 }

--- a/Localization/ru-RU/Mods.SpiritReforged.Items.hjson
+++ b/Localization/ru-RU/Mods.SpiritReforged.Items.hjson
@@ -1600,11 +1600,19 @@ BombCannon: {
 }
 
 RadonMossBobberItem: {
-	// DisplayName: Radon Moss Bobber Item
-	// Tooltip: ""
+	// DisplayName: Radon Moss Fishing Bobber
+	/* Tooltip:
+		'''
+		Increases fishing power by 10
+		Your bobber now glows
+		''' */
 }
 
 OganessonMossBobberItem: {
-	// DisplayName: Oganesson Moss Bobber Item
-	// Tooltip: ""
+	// DisplayName: Oganesson Moss Fishing Bobber
+	/* Tooltip:
+		'''
+		Increases fishing power by 10
+		Your bobber now glows
+		''' */
 }

--- a/Localization/ru-RU/Mods.SpiritReforged.Tiles.hjson
+++ b/Localization/ru-RU/Mods.SpiritReforged.Tiles.hjson
@@ -35,3 +35,13 @@ TermiteJar_Tile.MapEntry: Банка с термитами
 GarInAJarTile.MapEntry: Щука в банке
 KillieFishbowlTile.MapEntry: Аквариум с килли рыбкой
 // OreCarts.MapEntry: Minecart
+// AetherShipment.MapEntry: Aether Shipment
+// ScryingPot.MapEntry: Scrying Pot
+// SilverPlatters.MapEntry: Silver Platters
+// StuffedPots.MapEntry: Stuffed Pots
+// WormPot.MapEntry: Worm Pot
+// AetherShipmentRubble.MapEntry: Aether Shipment Rubble
+// ScryingPotRubble.MapEntry: Scrying Pot Rubble
+// SilverPlattersRubble.MapEntry: Silver Platters Rubble
+// StuffedPotsRubble.MapEntry: Stuffed Pots Rubble
+// WormPotRubble.MapEntry: Worm Pot Rubble

--- a/Localization/ru-RU/Mods.SpiritReforged.Tiles.hjson
+++ b/Localization/ru-RU/Mods.SpiritReforged.Tiles.hjson
@@ -35,13 +35,13 @@ TermiteJar_Tile.MapEntry: Банка с термитами
 GarInAJarTile.MapEntry: Щука в банке
 KillieFishbowlTile.MapEntry: Аквариум с килли рыбкой
 // OreCarts.MapEntry: Minecart
-// AetherShipment.MapEntry: Aether Shipment
-// ScryingPot.MapEntry: Scrying Pot
-// SilverPlatters.MapEntry: Silver Platters
-// StuffedPots.MapEntry: Stuffed Pots
-// WormPot.MapEntry: Worm Pot
-// AetherShipmentRubble.MapEntry: Aether Shipment Rubble
-// ScryingPotRubble.MapEntry: Scrying Pot Rubble
-// SilverPlattersRubble.MapEntry: Silver Platters Rubble
-// StuffedPotsRubble.MapEntry: Stuffed Pots Rubble
-// WormPotRubble.MapEntry: Worm Pot Rubble
+// AetherShipment.MapEntry: "{$AetherShipmentItem.DisplayName}"
+// ScryingPot.MapEntry: "{$ScryingPotItem.DisplayName}"
+// SilverPlatters.MapEntry: "{$SilverPlattersItem.DisplayName}"
+// StuffedPots.MapEntry: "{$StuffedPotsItem.DisplayName}"
+// WormPot.MapEntry: "{$WormPotItem.DisplayName}"
+// AetherShipmentRubble.MapEntry: "{$AetherShipmentItem.DisplayName}"
+// ScryingPotRubble.MapEntry: "{$ScryingPotItem.DisplayName}"
+// SilverPlattersRubble.MapEntry: "{$SilverPlattersItem.DisplayName}"
+// StuffedPotsRubble.MapEntry: "{$StuffedPotsItem.DisplayName}"
+// WormPotRubble.MapEntry: "{$WormPotItem.DisplayName}"

--- a/Localization/zh-Hans/Mods.SpiritReforged.Items.hjson
+++ b/Localization/zh-Hans/Mods.SpiritReforged.Items.hjson
@@ -1609,18 +1609,10 @@ BombCannon: {
 
 RadonMossBobberItem: {
 	// DisplayName: Radon Moss Fishing Bobber
-	/* Tooltip:
-		'''
-		Increases fishing power by 10
-		Your bobber now glows
-		''' */
+	// Tooltip: "{$ItemTooltip.FishingBobberGlowingArgon}"
 }
 
 OganessonMossBobberItem: {
 	// DisplayName: Oganesson Moss Fishing Bobber
-	/* Tooltip:
-		'''
-		Increases fishing power by 10
-		Your bobber now glows
-		''' */
+	// Tooltip: "{$ItemTooltip.FishingBobberGlowingArgon}"
 }

--- a/Localization/zh-Hans/Mods.SpiritReforged.Items.hjson
+++ b/Localization/zh-Hans/Mods.SpiritReforged.Items.hjson
@@ -1608,11 +1608,19 @@ BombCannon: {
 }
 
 RadonMossBobberItem: {
-	// DisplayName: Radon Moss Bobber Item
-	// Tooltip: ""
+	// DisplayName: Radon Moss Fishing Bobber
+	/* Tooltip:
+		'''
+		Increases fishing power by 10
+		Your bobber now glows
+		''' */
 }
 
 OganessonMossBobberItem: {
-	// DisplayName: Oganesson Moss Bobber Item
-	// Tooltip: ""
+	// DisplayName: Oganesson Moss Fishing Bobber
+	/* Tooltip:
+		'''
+		Increases fishing power by 10
+		Your bobber now glows
+		''' */
 }

--- a/Localization/zh-Hans/Mods.SpiritReforged.Tiles.hjson
+++ b/Localization/zh-Hans/Mods.SpiritReforged.Tiles.hjson
@@ -35,3 +35,13 @@ TermiteJar_Tile.MapEntry: 白蚁罐
 GarInAJarTile.MapEntry: 罐中雀鳝
 KillieFishbowlTile.MapEntry: 鳉鱼鱼缸
 // OreCarts.MapEntry: Minecart
+// AetherShipment.MapEntry: Aether Shipment
+// ScryingPot.MapEntry: Scrying Pot
+// SilverPlatters.MapEntry: Silver Platters
+// StuffedPots.MapEntry: Stuffed Pots
+// WormPot.MapEntry: Worm Pot
+// AetherShipmentRubble.MapEntry: Aether Shipment Rubble
+// ScryingPotRubble.MapEntry: Scrying Pot Rubble
+// SilverPlattersRubble.MapEntry: Silver Platters Rubble
+// StuffedPotsRubble.MapEntry: Stuffed Pots Rubble
+// WormPotRubble.MapEntry: Worm Pot Rubble

--- a/Localization/zh-Hans/Mods.SpiritReforged.Tiles.hjson
+++ b/Localization/zh-Hans/Mods.SpiritReforged.Tiles.hjson
@@ -35,13 +35,13 @@ TermiteJar_Tile.MapEntry: 白蚁罐
 GarInAJarTile.MapEntry: 罐中雀鳝
 KillieFishbowlTile.MapEntry: 鳉鱼鱼缸
 // OreCarts.MapEntry: Minecart
-// AetherShipment.MapEntry: Aether Shipment
-// ScryingPot.MapEntry: Scrying Pot
-// SilverPlatters.MapEntry: Silver Platters
-// StuffedPots.MapEntry: Stuffed Pots
-// WormPot.MapEntry: Worm Pot
-// AetherShipmentRubble.MapEntry: Aether Shipment Rubble
-// ScryingPotRubble.MapEntry: Scrying Pot Rubble
-// SilverPlattersRubble.MapEntry: Silver Platters Rubble
-// StuffedPotsRubble.MapEntry: Stuffed Pots Rubble
-// WormPotRubble.MapEntry: Worm Pot Rubble
+// AetherShipment.MapEntry: "{$AetherShipmentItem.DisplayName}"
+// ScryingPot.MapEntry: "{$ScryingPotItem.DisplayName}"
+// SilverPlatters.MapEntry: "{$SilverPlattersItem.DisplayName}"
+// StuffedPots.MapEntry: "{$StuffedPotsItem.DisplayName}"
+// WormPot.MapEntry: "{$WormPotItem.DisplayName}"
+// AetherShipmentRubble.MapEntry: "{$AetherShipmentItem.DisplayName}"
+// ScryingPotRubble.MapEntry: "{$ScryingPotItem.DisplayName}"
+// SilverPlattersRubble.MapEntry: "{$SilverPlattersItem.DisplayName}"
+// StuffedPotsRubble.MapEntry: "{$StuffedPotsItem.DisplayName}"
+// WormPotRubble.MapEntry: "{$WormPotItem.DisplayName}"


### PR DESCRIPTION
- Made Pots metal detectable
- Added AddMapData(), a method that allows pottiles to have custom map data easily
- Updated map colors for uncommon pots
- Updated map colors and names for rare pots
- Scrying Pot Loot: now drops one 'sight' related potion and silver coins