### PR TITLE
add failsafe to blunderbuss & pearl necklace discoveries, ocean popul…

### DIFF
--- a/Common/WorldGeneration/Micropasses/Discoveries/Passes/BlunderbussDiscovery.cs
+++ b/Common/WorldGeneration/Micropasses/Discoveries/Passes/BlunderbussDiscovery.cs
@@ -16,16 +16,27 @@ internal class BlunderbussDiscovery : Discovery
 
 	public override void Run(GenerationProgress progress, GameConfiguration config)
 	{
+		const int MaxRepeats = 1500;
+
 		progress.Message = Language.GetTextValue("Mods.SpiritReforged.Generation.Discoveries");
+		int repeats = 0;
 
 		retry:
+		repeats++;
+
+		if (repeats > MaxRepeats)
+			return;
+
 		int x = WorldGen.genRand.NextBool() ? WorldGen.genRand.Next(GenVars.rightBeachStart, Main.maxTilesX) : WorldGen.genRand.Next(0, GenVars.leftBeachEnd);
 		int y = (int)(Main.worldSurface * 0.35); //Sky height
 
-		int type = ModContent.TileType<BlunderbussTile>();
+		if (repeats > 1200) // Add safeguard for mods like Remnants which may block sky access
+			y = (int)Main.worldSurface - WorldGen.genRand.Next(300, 200);
 
-		WorldMethods.FindGround(x, ref y);
-		if (Main.tile[x, y - 1].LiquidAmount == 255)
+		int type = ModContent.TileType<BlunderbussTile>();
+		bool foundGround = WorldMethods.SafeFindGround(x, ref y);
+
+		if (!foundGround || Main.tile[x, y - 1].LiquidAmount == 255)
 			goto retry;
 
 		WorldGen.PlaceTile(x, y - 1, type);

--- a/Common/WorldGeneration/Micropasses/Discoveries/Passes/PearlDiscovery.cs
+++ b/Common/WorldGeneration/Micropasses/Discoveries/Passes/PearlDiscovery.cs
@@ -16,17 +16,28 @@ internal class PearlDiscovery : Discovery
 
 	public override void Run(GenerationProgress progress, GameConfiguration config)
 	{
+		const int MaxRepeats = 1500;
+
 		progress.Message = Language.GetTextValue("Mods.SpiritReforged.Generation.Discoveries");
+		int repeats = 0;
 
 		while (true)
 		{
+			repeats++;
+
+			if (repeats > MaxRepeats)
+				return;
+
 			int x = WorldGen.genRand.NextBool() ? WorldGen.genRand.Next(GenVars.rightBeachStart, Main.maxTilesX) : WorldGen.genRand.Next(0, GenVars.leftBeachEnd);
 			int y = (int)(Main.worldSurface * 0.35); //Sky height
 
-			int type = ModContent.TileType<PearlStringTile>();
+			if (repeats > 1200) // Add safeguard for mods like Remnants which may block sky access
+				y = (int)Main.worldSurface - WorldGen.genRand.Next(300, 200);
 
-			WorldMethods.FindGround(x, ref y);
-			if (Main.tile[x, y - 1].LiquidAmount == 255)
+			int type = ModContent.TileType<PearlStringTile>();
+			bool foundGround = WorldMethods.SafeFindGround(x, ref y);
+
+			if (!foundGround || Main.tile[x, y - 1].LiquidAmount == 255)
 				continue;
 
 			WorldGen.PlaceTile(x, y - 1, type);

--- a/Common/WorldGeneration/WorldMethods.cs
+++ b/Common/WorldGeneration/WorldMethods.cs
@@ -38,6 +38,32 @@ public class WorldMethods
 		return j;
 	}
 
+	/// <summary> Scans up, then down for the nearest surface tile. Breaks if near any world edge and returns false. </summary>
+	public static bool SafeFindGround(int i, ref int j)
+	{
+		while (WorldGen.SolidOrSlopedTile(i, j - 1))
+		{
+			if (!WorldGen.InWorld(i, j, 5))
+			{
+				return false;
+			}
+
+			j--; //Up
+		}
+
+		while (!WorldGen.SolidOrSlopedTile(i, j))
+		{
+			if (!WorldGen.InWorld(i, j, 5))
+			{
+				return false;
+			}
+
+			j++; //Down
+		}
+
+		return true;
+	}
+
 	public static void CragSpike(int X, int Y, int length, int height, ushort type2, float slope, float sloperight)
 	{
 		float trueslope = 1 / slope;

--- a/Content/Ocean/OceanGeneration.cs
+++ b/Content/Ocean/OceanGeneration.cs
@@ -135,6 +135,13 @@ public class OceanGeneration : ModSystem
 		progress.Message = Language.GetTextValue("Mods.SpiritReforged.Generation.PopulateOcean");
 
 		PlaceOceanPendant();
+
+		if (_oceanInfos.Item1 == Rectangle.Empty || _oceanInfos.Item2 == Rectangle.Empty)
+		{
+			_oceanInfos.Item1 = new Rectangle(40, (int)Main.worldSurface - 200, WorldGen.beachDistance, 200);
+			_oceanInfos.Item2 = new Rectangle(Main.maxTilesX - 40 - WorldGen.beachDistance, (int)Main.worldSurface - 200, WorldGen.beachDistance, 200);
+		}
+
 		PlaceWaterChests(_oceanInfos.Item1, _oceanInfos.Item2);
 
 		PopulateOcean(_oceanInfos.Item1, 0);


### PR DESCRIPTION
- Adds repeat limit to both Blunderbuss and Pearl Necklace discoveries & varies placement at high repeats
- Assumes an ocean bounds if one isn't spawned for things which override base ocean