### PR TITLE
Club size modifiers

### DIFF
--- a/Common/ItemCommon/ClubItem.cs
+++ b/Common/ItemCommon/ClubItem.cs
@@ -1,7 +1,6 @@
 ﻿using Terraria.DataStructures;
 using SpiritReforged.Common.ProjectileCommon.Abstract;
 using SpiritReforged.Common.ProjectileCommon;
-using SpiritReforged.Content.Vanilla.Leather.HideTunic;
 
 namespace SpiritReforged.Common.ItemCommon;
 

--- a/Common/ItemCommon/ClubItem.cs
+++ b/Common/ItemCommon/ClubItem.cs
@@ -1,6 +1,7 @@
 ﻿using Terraria.DataStructures;
 using SpiritReforged.Common.ProjectileCommon.Abstract;
 using SpiritReforged.Common.ProjectileCommon;
+using SpiritReforged.Content.Vanilla.Leather.HideTunic;
 
 namespace SpiritReforged.Common.ItemCommon;
 
@@ -31,6 +32,9 @@ public abstract class ClubItem : ModItem
 	}
 
 	public override bool? CanAutoReuseItem(Player player) => false;
+
+	public override bool MeleePrefix() => true;
+
 	public override Vector2? HoldoutOffset() => new Vector2(-10, 0);
 
 	public override bool Shoot(Player player, EntitySource_ItemUse_WithAmmo source, Vector2 position, Vector2 velocity, int type, int damage, float knockback)
@@ -41,11 +45,14 @@ public abstract class ClubItem : ModItem
 			float speedMult = player.GetTotalAttackSpeed(DamageClass.Melee);
 			float swingSpeedMult = MathHelper.Lerp(speedMult, 1, 0.5f);
 
+			float scale = player.GetAdjustedItemScale(Item);
+
 			clubProj.SetStats(
 				(int)(ChargeTime * MathHelper.Max(.15f, 2 - speedMult)),
 				(int)(SwingTime * MathHelper.Max(.15f, 2 - swingSpeedMult)),
 				DamageScaling,
-				KnockbackScaling);
+				KnockbackScaling,
+				scale);
 		});
 
 		return false;

--- a/Common/ProjectileCommon/Abstract/BaseClubCommon.cs
+++ b/Common/ProjectileCommon/Abstract/BaseClubCommon.cs
@@ -14,6 +14,20 @@ public abstract partial class BaseClubProj : ModProjectile
 		POST_SMASH
 	}
 
+	public float GetSwingProgress => SwingSpeedMult * _swingTimer / SwingTime;
+
+	public float GetWindupProgress => (ChargeTime > 0) ? _windupTimer / (float)WindupTime : 0;
+
+	public float TotalScale => BaseScale * MeleeSizeModifier;
+
+	public float BaseScale { get => Projectile.scale; set => Projectile.scale = value; }
+
+	public float AngleRange => SwingAngle_Max - HoldAngle_Final;
+
+	public bool FullCharge => Charge == 1;
+
+	public Player Owner => Main.player[Projectile.owner];
+
 	public bool CheckAIState(AIStates checkState) => AiState == (float)checkState;
 
 	public void SetAIState(AIStates setState)
@@ -32,12 +46,13 @@ public abstract partial class BaseClubProj : ModProjectile
 		Charge = 0;
 	}
 
-	public void SetStats(int chargeTime, int swingTime, float damageScaling, float knockbackScaling)
+	public void SetStats(int chargeTime, int swingTime, float damageScaling, float knockbackScaling, float sizeModifier)
 	{
 		ChargeTime = chargeTime;
 		SwingTime = swingTime;
 		DamageScaling = damageScaling;
 		KnockbackScaling = knockbackScaling;
+		MeleeSizeModifier = sizeModifier;
 
 		ResetData();
 	}
@@ -56,7 +71,7 @@ public abstract partial class BaseClubProj : ModProjectile
 		armRotation = output;
 	}
 
-	internal static void DoShockwaveCircle(Vector2 pos, float size, float xyRotation, float opacity)
+	internal void DoShockwaveCircle(Vector2 pos, float size, float xyRotation, float opacity)
 	{
 		var easeFunction = EaseCubicOut;
 		float ringWidth = 0.4f;
@@ -68,7 +83,7 @@ public abstract partial class BaseClubProj : ModProjectile
 			Color.LightGray * opacity,
 			Color.LightGray * opacity,
 			ringWidth,
-			size,
+			size * TotalScale,
 			lifetime,
 			"supPerlin",
 			new Vector2(2, 3),
@@ -84,7 +99,7 @@ public abstract partial class BaseClubProj : ModProjectile
 		{
 			Vector2 smokePos = Projectile.Bottom + Vector2.UnitX * Main.rand.NextFloat(-20, 20);
 
-			float scale = Main.rand.NextFloat(0.05f, 0.07f);
+			float scale = Main.rand.NextFloat(0.05f, 0.07f) * TotalScale;
 			scale *= 1 + chargeFactor / 2;
 
 			float speed = Main.rand.NextFloat(4);
@@ -115,19 +130,9 @@ public abstract partial class BaseClubProj : ModProjectile
 
 			float progress = (Projectile.oldPos.Length - k) / (float)Projectile.oldPos.Length;
 			Color trailColor = drawColor * progress * .125f;
-			Main.EntitySpriteDraw(texture, drawPos, topFrame, trailColor, Projectile.oldRot[k], HoldPoint, Projectile.scale, Effects, 0);
+			Main.EntitySpriteDraw(texture, drawPos, topFrame, trailColor, Projectile.oldRot[k], HoldPoint, TotalScale, Effects, 0);
 		}
 	}
 
-	public float GetSwingProgress => SwingSpeedMult * _swingTimer / SwingTime;
-
-	public float GetWindupProgress => (ChargeTime > 0) ? _windupTimer / (float)WindupTime : 0;
-
 	public static float GetSwingProgressStatic(Projectile Proj) => Proj.ModProjectile is BaseClubProj baseClub ? EaseQuadOut.Ease(baseClub.GetSwingProgress) : 0;
-
-	public float AngleRange => SwingAngle_Max - HoldAngle_Final;
-
-	public bool FullCharge => Charge == 1;
-
-	public Player Owner => Main.player[Projectile.owner];
 }

--- a/Common/ProjectileCommon/Abstract/BaseClubCommon.cs
+++ b/Common/ProjectileCommon/Abstract/BaseClubCommon.cs
@@ -20,8 +20,6 @@ public abstract partial class BaseClubProj : ModProjectile
 
 	public float TotalScale => BaseScale * MeleeSizeModifier;
 
-	public float BaseScale { get => Projectile.scale; set => Projectile.scale = value; }
-
 	public float AngleRange => SwingAngle_Max - HoldAngle_Final;
 
 	public bool FullCharge => Charge == 1;

--- a/Common/ProjectileCommon/Abstract/BaseClubCommon.cs
+++ b/Common/ProjectileCommon/Abstract/BaseClubCommon.cs
@@ -7,6 +7,36 @@ namespace SpiritReforged.Common.ProjectileCommon.Abstract;
 
 public abstract partial class BaseClubProj : ModProjectile
 {
+	/// <summary>
+	/// Returns the current progress through the club's swing, adjusted for the swing speed multiplier.
+	/// </summary>
+	public float GetSwingProgress => SwingSpeedMult * _swingTimer / SwingTime;
+
+	/// <summary>
+	/// Returns the current progress through the club's windup. Returns 0 if the club has completed the windup and has started charging.
+	/// </summary>
+	public float GetWindupProgress => (ChargeTime > 0) ? _windupTimer / (float)WindupTime : 0;
+
+	/// <summary>
+	/// Returns the scale to draw the club with, using the product of the club's base scale and the melee size modifier set at projectile creation.
+	/// </summary>
+	public float TotalScale => BaseScale * MeleeSizeModifier;
+
+	/// <summary>
+	/// Returns the total amount of radians the club will swing, using the starting angle and the final angle of the swing.
+	/// </summary>
+	public float AngleRange => SwingAngle_Max - HoldAngle_Final;
+
+	/// <summary>
+	/// Checks if the club is fully charge. Use in most instances of checking for charge, for a binary charge rather than a gradient.
+	/// </summary>
+	public bool FullCharge => Charge == 1;
+
+	/// <summary>
+	/// Returns the projectile's owner.
+	/// </summary>
+	public Player Owner => Main.player[Projectile.owner];
+
 	public enum AIStates
 	{
 		CHARGING,
@@ -14,26 +44,27 @@ public abstract partial class BaseClubProj : ModProjectile
 		POST_SMASH
 	}
 
-	public float GetSwingProgress => SwingSpeedMult * _swingTimer / SwingTime;
-
-	public float GetWindupProgress => (ChargeTime > 0) ? _windupTimer / (float)WindupTime : 0;
-
-	public float TotalScale => BaseScale * MeleeSizeModifier;
-
-	public float AngleRange => SwingAngle_Max - HoldAngle_Final;
-
-	public bool FullCharge => Charge == 1;
-
-	public Player Owner => Main.player[Projectile.owner];
-
+	/// <summary>
+	/// Shorthand form of checking the current AI state of the club, without needing to cast the enumerator back to a float.
+	/// </summary>
+	/// <param name="checkState"></param>
+	/// <returns></returns>
 	public bool CheckAIState(AIStates checkState) => AiState == (float)checkState;
 
+	/// <summary>
+	/// Shorthand form of changing the AI state of the club without needing to cast the enumerator, in addition to syncing the change.
+	/// </summary>
+	/// <param name="setState"></param>
 	public void SetAIState(AIStates setState)
 	{
 		AiState = (float)setState;
 		Projectile.netUpdate = true;
 	}
 
+	/// <summary>
+	/// Resets all timers and charge back to 0, in addition to setting the flickered flag to false. <br />
+	/// Used for initialization, and for club combos that have multiple chargable swings.
+	/// </summary>
 	public void ResetData()
 	{
 		_lingerTimer = LingerTime;
@@ -44,6 +75,14 @@ public abstract partial class BaseClubProj : ModProjectile
 		Charge = 0;
 	}
 
+	/// <summary>
+	/// Sets the relevant stats of the club weapon to the club projectile.
+	/// </summary>
+	/// <param name="chargeTime"></param>
+	/// <param name="swingTime"></param>
+	/// <param name="damageScaling"></param>
+	/// <param name="knockbackScaling"></param>
+	/// <param name="sizeModifier"></param>
 	public void SetStats(int chargeTime, int swingTime, float damageScaling, float knockbackScaling, float sizeModifier)
 	{
 		ChargeTime = chargeTime;
@@ -55,6 +94,12 @@ public abstract partial class BaseClubProj : ModProjectile
 		ResetData();
 	}
 
+	/// <summary>
+	/// Translates the club's base rotation to the value needed for drawing the projectile and player arm, without the programmer needing to offset the rotation and account for player direction.
+	/// </summary>
+	/// <param name="owner"></param>
+	/// <param name="clubRotation"></param>
+	/// <param name="armRotation"></param>
 	private void TranslateRotation(Player owner, out float clubRotation, out float armRotation)
 	{
 		float output = BaseRotation * owner.gravDir + 1.7f;
@@ -69,6 +114,13 @@ public abstract partial class BaseClubProj : ModProjectile
 		armRotation = output;
 	}
 
+	/// <summary>
+	/// Quickly does a shockwave circle visual, used primarily for clubs slamming into tiles.
+	/// </summary>
+	/// <param name="pos"></param>
+	/// <param name="size"></param>
+	/// <param name="xyRotation"></param>
+	/// <param name="opacity"></param>
 	internal void DoShockwaveCircle(Vector2 pos, float size, float xyRotation, float opacity)
 	{
 		var easeFunction = EaseCubicOut;
@@ -88,6 +140,10 @@ public abstract partial class BaseClubProj : ModProjectile
 			easeFunction).WithSkew(zRotation, xyRotation).UsesLightColor());
 	}
 
+	/// <summary>
+	/// Quickly does a dust cloud visual, used primarily for clubs slamming into tiles.
+	/// </summary>
+	/// <param name="maxClouds"></param>
 	internal void DustClouds(int maxClouds)
 	{
 		float chargeFactor = Clamp(EaseQuadIn.Ease(Charge), 0.33f, 1f);
@@ -110,6 +166,10 @@ public abstract partial class BaseClubProj : ModProjectile
 		}
 	}
 
+	/// <summary>
+	/// Shorthand form for drawing the club's aftertrail, used by default during the swing.
+	/// </summary>
+	/// <param name="lightColor"></param>
 	internal void DrawAftertrail(Color lightColor)
 	{
 		Texture2D texture = TextureAssets.Projectile[Projectile.type].Value;
@@ -132,5 +192,11 @@ public abstract partial class BaseClubProj : ModProjectile
 		}
 	}
 
+	/// <summary>
+	/// Returns a static function to be used for the club's vertex strip. <br />
+	/// Assumes default swinging behavior, if the vertex strip doesn't match the swing, create a different local static function to match it.
+	/// </summary>
+	/// <param name="Proj"></param>
+	/// <returns></returns>
 	public static float GetSwingProgressStatic(Projectile Proj) => Proj.ModProjectile is BaseClubProj baseClub ? EaseQuadOut.Ease(baseClub.GetSwingProgress) : 0;
 }

--- a/Common/ProjectileCommon/Abstract/BaseClubProj.cs
+++ b/Common/ProjectileCommon/Abstract/BaseClubProj.cs
@@ -26,6 +26,7 @@ public abstract partial class BaseClubProj(Vector2 textureSize) : ModProjectile
 	public float Charge { get => Projectile.ai[0]; set => Projectile.ai[0] = value; }
 	public float AiState { get => Projectile.ai[1]; set => Projectile.ai[1] = value; }
 	public float BaseRotation { get => Projectile.ai[2]; set => Projectile.ai[2] = value; }
+	public float BaseScale { get => Projectile.scale; set => Projectile.scale = value; }
 
 	protected int _lingerTimer;
 	protected int _swingTimer;

--- a/Common/ProjectileCommon/Abstract/BaseClubProj.cs
+++ b/Common/ProjectileCommon/Abstract/BaseClubProj.cs
@@ -18,6 +18,7 @@ public abstract partial class BaseClubProj(Vector2 textureSize) : ModProjectile
 
 	public int ChargeTime { get; private set; }
 	public int SwingTime { get; private set; }
+	public float MeleeSizeModifier { get; private set; }
 
 	internal int WindupTime => (int)(ChargeTime * WindupTimeRatio);
 	internal int LingerTime => (int)(SwingTime * LingerTimeRatio);
@@ -75,9 +76,9 @@ public abstract partial class BaseClubProj(Vector2 textureSize) : ModProjectile
 	{
 		float dummy = 0;
 		float lineWidth = Size.Length() / 2;
-		var endPoint = Vector2.Lerp(Main.player[Projectile.owner].Center, Projectile.Center, Projectile.scale);
+		var endPoint = Owner.MountedCenter + Owner.DirectionTo(Projectile.Center) * TotalScale * Size;
 
-		return Collision.CheckAABBvLineCollision(targetHitbox.TopLeft(), targetHitbox.Size(), Main.player[Projectile.owner].Center, endPoint, lineWidth, ref dummy);
+		return Collision.CheckAABBvLineCollision(targetHitbox.TopLeft(), targetHitbox.Size(), Owner.MountedCenter, endPoint, lineWidth, ref dummy);
 	}
 
 	public override bool? CanDamage() => CheckAIState(AIStates.SWINGING) ? null : false;
@@ -176,7 +177,7 @@ public abstract partial class BaseClubProj(Vector2 textureSize) : ModProjectile
 		if (CheckAIState(AIStates.SWINGING))
 			DrawAftertrail(lightColor);
 
-		Main.EntitySpriteDraw(texture, drawPos, topFrame, drawColor, Projectile.rotation, HoldPoint, Projectile.scale, Effects, 0);
+		Main.EntitySpriteDraw(texture, drawPos, topFrame, drawColor, Projectile.rotation, HoldPoint, TotalScale, Effects, 0);
 
 		SafeDraw(Main.spriteBatch, lightColor);
 
@@ -186,7 +187,7 @@ public abstract partial class BaseClubProj(Vector2 textureSize) : ModProjectile
 			Texture2D flash = TextureColorCache.ColorSolid(texture, Color.White);
 			float alpha = EaseQuadIn.Ease(EaseSine.Ease(_flickerTime / (float)MAX_FLICKERTIME));
 
-			Main.EntitySpriteDraw(flash, drawPos, topFrame, Color.White * alpha, Projectile.rotation, HoldPoint, Projectile.scale, Effects, 0);
+			Main.EntitySpriteDraw(flash, drawPos, topFrame, Color.White * alpha, Projectile.rotation, HoldPoint, TotalScale, Effects, 0);
 		}
 
 		return false;

--- a/Common/ProjectileCommon/Abstract/BaseClubVirtual.cs
+++ b/Common/ProjectileCommon/Abstract/BaseClubVirtual.cs
@@ -81,7 +81,7 @@ public abstract partial class BaseClubProj : ModProjectile
 		windupAnimProgress = Lerp(windupAnimProgress, Charge, PullbackWindupRatio);
 
 		BaseRotation = ChargedRotationInterpolate(windupAnimProgress);
-		Projectile.scale = ChargedScaleInterpolate(windupAnimProgress);
+		BaseScale = ChargedScaleInterpolate(windupAnimProgress);
 
 		--_flickerTime;
 	}
@@ -91,7 +91,7 @@ public abstract partial class BaseClubProj : ModProjectile
 		float swingProgress = GetSwingProgress;
 
 		bool validTile = Collision.SolidTiles(Projectile.position, Projectile.width, Projectile.height, true);
-		Projectile.scale = 1;
+		BaseScale = 1;
 
 		_swingTimer++;
 
@@ -118,7 +118,7 @@ public abstract partial class BaseClubProj : ModProjectile
 			float shrinkProgress = (swingProgress - SwingShrinkThreshold) / (1 - SwingShrinkThreshold);
 			shrinkProgress = Clamp(shrinkProgress, 0, 1);
 
-			Projectile.scale = Lerp(1, 0, EaseCubicIn.Ease(shrinkProgress));
+			BaseScale = Lerp(1, 0, EaseCubicIn.Ease(shrinkProgress));
 
 			if (swingProgress > 1)
 				Projectile.Kill();
@@ -136,7 +136,7 @@ public abstract partial class BaseClubProj : ModProjectile
 		float shrinkProgress = (lingerProgress - shrinkThreshold) / (1 - shrinkThreshold);
 		shrinkProgress = Clamp(shrinkProgress, 0, 1);
 
-		Projectile.scale = Lerp(1, 0, EaseCubicOut.Ease(EaseCircularIn.Ease(shrinkProgress)));
+		BaseScale = Lerp(1, 0, EaseCubicOut.Ease(EaseCircularIn.Ease(shrinkProgress)));
 
 		if (_lingerTimer <= 0)
 			Projectile.Kill();

--- a/Content/Forest/WoodClub/WoodClubProj.cs
+++ b/Content/Forest/WoodClub/WoodClubProj.cs
@@ -15,8 +15,8 @@ class WoodenClubProj : BaseClubProj, IManualTrailProjectile
 
 	public void DoTrailCreation(TrailManager tM)
 	{
-		float trailDist = 52;
-		float trailWidth = 30;
+		float trailDist = 52 * MeleeSizeModifier;
+		float trailWidth = 30 * MeleeSizeModifier;
 		float angleRangeMod = 1f;
 		float rotOffset = 0;
 
@@ -63,7 +63,7 @@ class WoodenClubProj : BaseClubProj, IManualTrailProjectile
 	public override void OnHitNPC(NPC target, NPC.HitInfo hit, int damageDone)
 	{
 		var basePosition = Vector2.Lerp(Projectile.Center, target.Center, 0.6f);
-		Vector2 directionUnit = basePosition.DirectionFrom(Owner.MountedCenter);
+		Vector2 directionUnit = basePosition.DirectionFrom(Owner.MountedCenter) * TotalScale;
 
 		int numParticles = FullCharge ? 12 : 8;
 		for(int i = 0; i < numParticles; i++)
@@ -79,7 +79,7 @@ class WoodenClubProj : BaseClubProj, IManualTrailProjectile
 			rotationOffset *= Main.rand.NextFloat(0.9f, 1.1f);
 
 			Vector2 particleVel = directionUnit.RotatedBy(rotationOffset) * velocity;
-			var p = new ImpactLine(position, particleVel, Color.White * 0.5f, new Vector2(0.15f, 0.6f), Main.rand.Next(15, 20), 0.8f);
+			var p = new ImpactLine(position, particleVel, Color.White * 0.5f, new Vector2(0.15f, 0.6f) * TotalScale, Main.rand.Next(15, 20), 0.8f);
 			p.UseLightColor = true;
 			ParticleHandler.SpawnParticle(p);
 
@@ -87,7 +87,7 @@ class WoodenClubProj : BaseClubProj, IManualTrailProjectile
 				Dust.NewDustPerfect(position, DustID.t_LivingWood, particleVel / 3, Scale: 0.5f);
 		}
 
-		ParticleHandler.SpawnParticle(new SmokeCloud(basePosition, directionUnit * 3, Color.LightGray, 0.06f, EaseFunction.EaseCubicOut, 30));
-		ParticleHandler.SpawnParticle(new SmokeCloud(basePosition, directionUnit * 6, Color.LightGray, 0.08f, EaseFunction.EaseCubicOut, 30));
+		ParticleHandler.SpawnParticle(new SmokeCloud(basePosition, directionUnit * 3, Color.LightGray, 0.06f * TotalScale, EaseFunction.EaseCubicOut, 30));
+		ParticleHandler.SpawnParticle(new SmokeCloud(basePosition, directionUnit * 6, Color.LightGray, 0.08f * TotalScale, EaseFunction.EaseCubicOut, 30));
 	}
 }

--- a/Content/Particles/Shatter.cs
+++ b/Content/Particles/Shatter.cs
@@ -8,20 +8,21 @@ namespace SpiritReforged.Content.Particles;
 public class Shatter : Particle
 {
 	Color _baseColor;
+	float _baseScale;
 
-	public Shatter(Vector2 position, Color baseColor, int maxTime)
+	public Shatter(Vector2 position, Color baseColor, float scale, int maxTime)
 	{
 		Position = position;
 		Rotation = Main.rand.NextFloat(TwoPi);
 		MaxTime = maxTime;
-		Scale = 0.3f;
+		_baseScale = scale;
 		_baseColor = baseColor;
 	}
 
 	public override void Update()
 	{
 		Color = _baseColor * EaseQuadOut.Ease(1 - Progress);
-		Scale = Lerp(0.48f, 0.55f, EaseSine.Ease(EaseCubicOut.Ease(Progress)));
+		Scale = Lerp(0.48f, 0.55f, EaseSine.Ease(EaseCubicOut.Ease(Progress))) * _baseScale;
 	}
 
 	public override ParticleDrawType DrawType => ParticleDrawType.CustomBatchedAdditiveBlend;

--- a/Content/Underground/Items/OreClubs/GoldClubProj.cs
+++ b/Content/Underground/Items/OreClubs/GoldClubProj.cs
@@ -21,8 +21,8 @@ class GoldClubProj : BaseClubProj, IManualTrailProjectile
 
 	public override float WindupTimeRatio => 0.8f;
 
-	public override float HoldAngle_Intial => base.HoldAngle_Intial * 1.5f;
-	public override float HoldAngle_Final => Direction * -base.HoldAngle_Final / 3 - (Direction < 0 ? PiOver4 * 0.66f : 0);
+	public override float HoldAngle_Intial => base.HoldAngle_Intial;
+	public override float HoldAngle_Final => Direction * base.HoldAngle_Final / 3 - (Direction < 0 ? PiOver4 * 0.66f : 0);
 	public override float SwingAngle_Max => Direction * base.SwingAngle_Max * 1.1f - (Direction < 0 ? PiOver4 * 1.1f : 0);
 
 	public override float LingerTimeRatio => 1.5f;
@@ -42,7 +42,7 @@ class GoldClubProj : BaseClubProj, IManualTrailProjectile
 
 		Vector2 directionUnit = rotation.ToRotationVector2();
 
-		return handPos + directionUnit * 70 * Projectile.scale;
+		return handPos + directionUnit * 70 * TotalScale;
 	}
 
 	internal override float ChargedScaleInterpolate(float progress) => (Direction == 1) ? base.ChargedScaleInterpolate(progress) : 1;
@@ -53,8 +53,8 @@ class GoldClubProj : BaseClubProj, IManualTrailProjectile
 
 	public void DoTrailCreation(TrailManager tM)
 	{
-		float trailDist = 78;
-		float trailWidth = 25;
+		float trailDist = 78 * MeleeSizeModifier;
+		float trailWidth = 25 * MeleeSizeModifier;
 		float intensity = 3;
 		float trailLengthMod = 1f;
 		float rotation = HoldAngle_Final - PiOver4 / 2;
@@ -164,7 +164,7 @@ class GoldClubProj : BaseClubProj, IManualTrailProjectile
 		}
 		else
 		{
-			Projectile.scale = Lerp(1, 0, EaseQuadOut.Ease(shrinkProgress));
+			BaseScale = Lerp(1, 0, EaseQuadOut.Ease(shrinkProgress));
 
 			if (_lingerTimer <= 0)
 				Projectile.Kill();
@@ -199,7 +199,7 @@ class GoldClubProj : BaseClubProj, IManualTrailProjectile
 			var position = Vector2.Lerp(Projectile.Center, target.Center, 0.75f);
 			SoundEngine.PlaySound(SoundID.Item70.WithVolumeScale(0.5f), position);
 
-			float width = 260;
+			float width = 260 * TotalScale;
 
 			var pos = position + direction;
 			float rotation = direction.ToRotation();
@@ -209,18 +209,18 @@ class GoldClubProj : BaseClubProj, IManualTrailProjectile
 
 			float shineRotation = Main.rand.NextFloatDirection();
 			for(int i = 0; i < 3; i++)
-				ParticleHandler.SpawnParticle(new DissipatingImage(pos, DarkGold, shineRotation, 0.12f, 0, "GodrayCircle", new Vector2(0), new Vector2(3, 1.5f), 18));
+				ParticleHandler.SpawnParticle(new DissipatingImage(pos, DarkGold, shineRotation, 0.12f, 0, "GodrayCircle", new Vector2(0), new Vector2(3, 1.5f) * TotalScale, 18));
 
-			ParticleHandler.SpawnParticle(new Shatter(position, DarkGold, 40));
+			ParticleHandler.SpawnParticle(new Shatter(position, DarkGold, TotalScale, 40));
 
 			float numLines = 16;
 			for (int i = 0; i < numLines; i++)
 			{
-				Vector2 velocity = Vector2.UnitX.RotatedBy(TwoPi * i / numLines);
+				Vector2 velocity = Vector2.UnitX.RotatedBy(TwoPi * i / numLines) * TotalScale;
 				velocity = velocity.RotatedByRandom(PiOver4);
 				velocity *= Main.rand.NextFloat(4, 7);
 
-				var line = new ImpactLine(position, velocity, DarkGold.Additive() * 0.5f, new Vector2(0.2f, 0.6f), Main.rand.Next(15, 20), 0.9f);
+				var line = new ImpactLine(position, velocity, DarkGold.Additive() * 0.5f, new Vector2(0.2f, 0.6f) * TotalScale, Main.rand.Next(15, 20), 0.9f);
 				line.UseLightColor = true;
 				ParticleHandler.SpawnParticle(line);
 			}
@@ -231,13 +231,13 @@ class GoldClubProj : BaseClubProj, IManualTrailProjectile
 	{
 		Texture2D starTex = AssetLoader.LoadedTextures["Star"].Value;
 
-		float maxSize = 0.6f * Projectile.scale;
+		float maxSize = 0.6f * TotalScale;
 		float starProgress = EaseQuadIn.Ease(Charge);
 
 		Vector2 scale = new Vector2(Lerp(0.8f, 1.2f, EaseSine.Ease(Main.GlobalTimeWrappedHourly * 2f % 1)), 0.4f) * Lerp(0, maxSize, starProgress) * 0.7f;
 		var starOrigin = starTex.Size() / 2;
 
-		Color color = Projectile.GetAlpha(Ruby.Additive()) * EaseQuadIn.Ease(starProgress) * Projectile.scale * 0.5f;
+		Color color = Projectile.GetAlpha(Ruby.Additive()) * EaseQuadIn.Ease(starProgress) * BaseScale * 0.5f;
 
 		Main.spriteBatch.Draw(starTex, GetHammerTopPos() - Main.screenPosition, null, color, 0, starOrigin, scale, SpriteEffects.None, 0);
 	}

--- a/Content/Underground/Items/OreClubs/PlatinumClubProj.cs
+++ b/Content/Underground/Items/OreClubs/PlatinumClubProj.cs
@@ -26,8 +26,8 @@ class PlatinumClubProj : BaseClubProj, ITrailProjectile
 
 	public void DoTrailCreation(TrailManager tM)
 	{
-		float trailDist = 82;
-		float trailWidth = 26;
+		float trailDist = 82 * MeleeSizeModifier;
+		float trailWidth = 26 * MeleeSizeModifier;
 		static float windupSwingProgress(Projectile proj) => (proj.ModProjectile is BaseClubProj club) ? EaseCubicInOut.Ease(EaseCircularOut.Ease(Lerp(club.GetWindupProgress, 0, club.PullbackWindupRatio))) : 0;
 
 		Func<Projectile, float> uSwingFunc = CheckAIState(AIStates.SWINGING) ? GetSwingProgressStatic : windupSwingProgress;
@@ -116,7 +116,7 @@ class PlatinumClubProj : BaseClubProj, ITrailProjectile
 			if(CheckAIState(AIStates.SWINGING))
 			{
 				var pos = position + direction;
-				float width = 230;
+				float width = 230 * TotalScale;
 				float rotation = direction.ToRotation();
 
 				var p = new TexturedPulseCircle(pos, Color.White, Color.Silver, 0.6f, width, Main.rand.Next(20, 25), "Star2", new Vector2(4, 1), EaseCircularOut, false, 0.2f).WithSkew(.5f, rotation);
@@ -124,18 +124,18 @@ class PlatinumClubProj : BaseClubProj, ITrailProjectile
 
 				float shineRotation = Main.rand.NextFloatDirection();
 				for(int i = 0; i < 3; i++)
-					ParticleHandler.SpawnParticle(new DissipatingImage(pos, Color.White, shineRotation, 0.12f, 0, "GodrayCircle", new Vector2(0), new Vector2(4f, 1.5f), 18));
+					ParticleHandler.SpawnParticle(new DissipatingImage(pos, Color.White, shineRotation, 0.12f * TotalScale, 0, "GodrayCircle", new Vector2(0), new Vector2(4f, 1.5f), 18));
 				
-				ParticleHandler.SpawnParticle(new Shatter(position, Color.Silver, 40));
+				ParticleHandler.SpawnParticle(new Shatter(position, Color.Silver, TotalScale, 40));
 
 				float numLines = 16;
 				for(int i = 0; i < numLines; i++)
 				{
-					Vector2 velocity = Vector2.UnitX.RotatedBy(TwoPi * i / numLines);
+					Vector2 velocity = Vector2.UnitX.RotatedBy(TwoPi * i / numLines) * TotalScale;
 					velocity = velocity.RotatedByRandom(PiOver4);
 					velocity *= Main.rand.NextFloat(4, 7);
 
-					var line = new ImpactLine(position, velocity, Color.White * 0.5f, new Vector2(0.15f, 0.4f), Main.rand.Next(15, 20), 0.9f);
+					var line = new ImpactLine(position, velocity, Color.White * 0.5f, new Vector2(0.15f, 0.4f) * TotalScale, Main.rand.Next(15, 20), 0.9f);
 					line.UseLightColor = true;
 					ParticleHandler.SpawnParticle(line);
 				}
@@ -157,7 +157,7 @@ class PlatinumClubProj : BaseClubProj, ITrailProjectile
 			_lingerTimer -= 2;
 			float lingerProgress = _lingerTimer / (float)LingerTime;
 
-			Projectile.scale = Lerp(Projectile.scale, 0, EaseCircularOut.Ease(lingerProgress) / 4);
+			BaseScale = Lerp(BaseScale, 0, EaseCircularOut.Ease(lingerProgress) / 4);
 
 			if (_lingerTimer <= 0)
 				Projectile.Kill();

--- a/Localization/en-US/Mods.SpiritReforged.Items.hjson
+++ b/Localization/en-US/Mods.SpiritReforged.Items.hjson
@@ -1706,17 +1706,21 @@ LandscapingShears: {
 
 WoodenClub: {
 	DisplayName: Wooden Club
-	Tooltip: ""
+	Tooltip: "Can be charged to increase damage and knockback"
 }
 
 GoldClub: {
-	DisplayName: Gold Club
-	Tooltip: ""
+	DisplayName: Golden Greathammer
+	Tooltip: "Use again during a swing to follow up with a chargeable uppercut"
 }
 
 PlatinumClub: {
 	DisplayName: Platinum Club
-	Tooltip: ""
+	Tooltip: 
+		'''
+		Does an upwards swing that knocks enemies into the air
+		Hold to follow up with a downwards slam
+		'''
 }
 
 FrostGiantBelt: {


### PR DESCRIPTION
-Allows clubs to properly scale with melee size modifiers, including hide tunic
-Some slight reorganization, instances of projectile.scale are now replaced with "TotalScale" or renamed to "BaseScale" when not using the total scale including modifiers, to add some clarity between the use cases
-Renames the ore clubs and gives them tooltips explaining how to use them