### PR TITLE
Club multiplayer fixes

### DIFF
--- a/Common/PrimitiveRendering/TrailHelper.cs
+++ b/Common/PrimitiveRendering/TrailHelper.cs
@@ -78,7 +78,7 @@ public class TrailManager
 	/// <param name="send"> Whether trail creation should be synced. Not normally consistent because projectile.whoAmI differs between clients. </param>
 	public static void ManualTrailSpawn(Projectile projectile, bool send = false)
 	{
-		if (projectile.ModProjectile is not IManualTrailProjectile)
+		if (Main.dedServ || projectile.ModProjectile is not IManualTrailProjectile)
 			return;
 
 		if (send && Main.netMode != NetmodeID.SinglePlayer)

--- a/Common/PrimitiveRendering/TrailHelper.cs
+++ b/Common/PrimitiveRendering/TrailHelper.cs
@@ -75,14 +75,15 @@ public class TrailManager
 		}
 	}
 
-	public static void ManualTrailSpawn(Projectile projectile)
+	/// <param name="send"> Whether trail creation should be synced. Not normally consistent because projectile.whoAmI differs between clients. </param>
+	public static void ManualTrailSpawn(Projectile projectile, bool send = false)
 	{
-		if (projectile.ModProjectile is IManualTrailProjectile)
-		{
-			if (Main.netMode == NetmodeID.SinglePlayer)
-				(projectile.ModProjectile as IManualTrailProjectile).DoTrailCreation(AssetLoader.VertexTrailManager);
-			else
-				new SpawnTrailData(projectile.whoAmI).Send();
-		}
+		if (projectile.ModProjectile is not IManualTrailProjectile)
+			return;
+
+		if (send && Main.netMode != NetmodeID.SinglePlayer)
+			new SpawnTrailData(projectile.whoAmI).Send();
+		else
+			(projectile.ModProjectile as IManualTrailProjectile).DoTrailCreation(AssetLoader.VertexTrailManager);
 	}
 }

--- a/Common/ProjectileCommon/Abstract/BaseClubProj.cs
+++ b/Common/ProjectileCommon/Abstract/BaseClubProj.cs
@@ -81,6 +81,7 @@ public abstract partial class BaseClubProj(Vector2 textureSize) : ModProjectile
 		int width = (int)(projHitbox.Width * MeleeSizeModifier);
 		int height = (int)(projHitbox.Height * MeleeSizeModifier);
 		var newProjHitbox = new Rectangle((int)(endPoint.X - width / 2), (int)(endPoint.Y - height / 2), width, height);
+
 		if (newProjHitbox.Intersects(targetHitbox))
 			return true;
 
@@ -137,22 +138,16 @@ public abstract partial class BaseClubProj(Vector2 textureSize) : ModProjectile
 			Projectile.Kill();
 
 		Owner.heldProj = Projectile.whoAmI;
+		Owner.direction = Math.Sign(Projectile.direction);
 
-		if (AllowUseTurn)
+		if (AllowUseTurn && Projectile.owner == Main.myPlayer)
 		{
-			if (Owner == Main.LocalPlayer)
-			{
-				int newDir = Math.Sign(Main.MouseWorld.X - Owner.Center.X);
-				Projectile.velocity.X = newDir == 0 ? Owner.direction : newDir;
+			int newDir = Math.Sign(Main.MouseWorld.X - Owner.Center.X);
+			Projectile.velocity.X = newDir == 0 ? Owner.direction : newDir;
 
-				if (newDir != Owner.direction)
-					Projectile.netUpdate = true;
-			}
-
-			Owner.ChangeDir((int)Projectile.velocity.X);
+			if (newDir != Owner.direction)
+				Projectile.netUpdate = true;
 		}
-		else
-			Owner.direction = Math.Sign(Projectile.velocity.X);
 
 		switch (AiState)
 		{
@@ -232,9 +227,6 @@ public abstract partial class BaseClubProj(Vector2 textureSize) : ModProjectile
 		writer.Write((ushort)_swingTimer);
 		writer.Write((ushort)_windupTimer);
 
-		writer.Write((ushort)_flickerTime);
-		writer.Write(_hasFlickered);
-
 		SendExtraDataSafe(writer);
 	}
 
@@ -250,9 +242,6 @@ public abstract partial class BaseClubProj(Vector2 textureSize) : ModProjectile
 		_lingerTimer = reader.ReadUInt16();
 		_swingTimer = reader.ReadUInt16();
 		_windupTimer = reader.ReadUInt16();
-
-		_flickerTime = reader.ReadUInt16();
-		_hasFlickered = reader.ReadBoolean();
 
 		ReceiveExtraDataSafe(reader);
 	}

--- a/Common/ProjectileCommon/Abstract/BaseClubVirtual.cs
+++ b/Common/ProjectileCommon/Abstract/BaseClubVirtual.cs
@@ -74,7 +74,6 @@ public abstract partial class BaseClubProj : ModProjectile
 
 			_flickerTime = MAX_FLICKERTIME;
 			_hasFlickered = true;
-			Projectile.netUpdate = true;
 		}
 
 		float windupAnimProgress = _windupTimer / (float)WindupTime;

--- a/Content/Underground/Items/OreClubs/GoldClubProj.cs
+++ b/Content/Underground/Items/OreClubs/GoldClubProj.cs
@@ -99,7 +99,7 @@ class GoldClubProj : BaseClubProj, IManualTrailProjectile
 	{
 		base.Swinging(owner);
 
-		if(!Main.rand.NextBool(3) && GetSwingProgress < SwingShrinkThreshold)
+		if (!Main.rand.NextBool(3) && GetSwingProgress < SwingShrinkThreshold)
 		{
 			Vector2 particleVel = Projectile.position.DirectionFrom(Projectile.oldPosition).RotatedByRandom(Pi / 6) * Main.rand.NextFloat(3, 5);
 			int particleTime = Main.rand.Next(15, 25);
@@ -118,7 +118,7 @@ class GoldClubProj : BaseClubProj, IManualTrailProjectile
 		if (owner.controlUseItem && GetSwingProgress < SwingShrinkThreshold)
 			_inputHeld = true;
 
-		if(GetSwingProgress > SwingShrinkThreshold && Direction == 1 && _inputHeld)
+		if (GetSwingProgress > SwingShrinkThreshold && Direction == 1 && _inputHeld)
 		{
 			PrepareNextSwing();
 			return;
@@ -245,13 +245,13 @@ class GoldClubProj : BaseClubProj, IManualTrailProjectile
 
 	internal override void SendExtraDataSafe(BinaryWriter writer)
 	{
-		writer.Write((ushort)Direction);
+		writer.Write(Direction);
 		writer.Write(_inputHeld);
 	}
 
 	internal override void ReceiveExtraDataSafe(BinaryReader reader)
 	{
-		Direction = reader.ReadUInt16();
+		Direction = reader.ReadInt32();
 		_inputHeld = reader.ReadBoolean();
 	}
 }

--- a/Content/Underground/Items/OreClubs/GoldClubProj.cs
+++ b/Content/Underground/Items/OreClubs/GoldClubProj.cs
@@ -245,13 +245,13 @@ class GoldClubProj : BaseClubProj, IManualTrailProjectile
 
 	internal override void SendExtraDataSafe(BinaryWriter writer)
 	{
-		writer.Write(Direction);
+		writer.Write((sbyte)Direction);
 		writer.Write(_inputHeld);
 	}
 
 	internal override void ReceiveExtraDataSafe(BinaryReader reader)
 	{
-		Direction = reader.ReadInt32();
+		Direction = reader.ReadSByte();
 		_inputHeld = reader.ReadBoolean();
 	}
 }


### PR DESCRIPTION
- Fixed `GoldClubProj` writing `Direction` as an unsigned value for syncing
- Fixed players always facing left to other clients when charging a club
- Prevented several `BaseClubProj` variables from syncing unnecessarily
- Prevented `TrailManager.ManualTrailSpawn` from syncing by default