### PR TITLE
Traveling NPCs

### DIFF
--- a/Common/NPCCommon/Abstract/WorldNPC.cs
+++ b/Common/NPCCommon/Abstract/WorldNPC.cs
@@ -9,8 +9,7 @@ public abstract class WorldNPC : ModNPC
 	/// <summary> Whether this NPC has spawned today. Commonly checked in <see cref="SpawnChance"/> to prevent multiple spawns in one day. </summary>
 	public bool SpawnedToday => WorldNPCFlags.SpawnedToday[Name];
 
-	/// <summary>
-	/// <inheritdoc/><para/>
+	/// <summary><inheritdoc/><para/>
 	/// Automatically registers this NPC for <see cref="WorldNPCFlags.SpawnedToday"/>.<br/>
 	/// Additionally sets <see cref="NPCID.Sets.ActsLikeTownNPC"/> and <see cref="NPCID.Sets.NoTownNPCHappiness[Type]"/> to true.
 	/// </summary>
@@ -34,8 +33,7 @@ public abstract class WorldNPC : ModNPC
 
 	public override bool CanChat() => true; //Must be specified because this isn't a town NPC
 
-	/// <summary>
-	/// <inheritdoc/><para/>
+	/// <summary><inheritdoc/><para/>
 	/// Automatically sets <see cref="WorldNPCFlags.SpawnedToday"/>.
 	/// </summary>
 	public override void OnSpawn(IEntitySource source) => WorldNPCFlags.SpawnedToday[Name] = true;

--- a/Common/NPCCommon/ITravelNPC.cs
+++ b/Common/NPCCommon/ITravelNPC.cs
@@ -1,0 +1,127 @@
+﻿using SpiritReforged.Common.WorldGeneration;
+using System.Linq;
+using Terraria.Chat;
+
+namespace SpiritReforged.Common.NPCCommon;
+
+internal interface ITravelNPC
+{
+	public bool CanSpawnTraveler();
+}
+
+internal class TravelNPC : GlobalNPC
+{
+	public override bool CheckActive(NPC npc)
+	{
+		if (TravelFlags.TravelerSpawned)
+			return npc.ModNPC is not ITravelNPC;
+
+		return true;
+	}
+}
+
+internal class TravelFlags : ModSystem
+{
+	[WorldBound]
+	public static bool TravelerSpawned;
+	private static readonly Dictionary<int, Func<bool>> vDatabase = [];
+
+	/// <summary><inheritdoc cref="ModSystem.PostUpdateTime"/><para/>
+	/// Spawns a random <see cref="ITravelNPC"/> NPC where <see cref="ITravelNPC.CanSpawnTraveler"/> is true, and handles despawning like the traveling merchant. </summary>
+	public override void PostUpdateTime()
+	{
+		if (Main.netMode == NetmodeID.MultiplayerClient)
+			return;
+
+		if (TravelerSpawned)
+			TryDespawn();
+		else
+			TrySpawn();
+	}
+
+	private static void TrySpawn()
+	{
+		if (Main.eclipse || !Main.dayTime || Main.invasionType > 0 && Main.invasionDelay == 0 && Main.invasionSize > 0)
+			return;
+
+		if (!Main.IsFastForwardingTime() && Main.dayTime && Main.time < 27000.0 && Main.rand.NextDouble() < Main.dayRate / 108000.0)
+		{
+			if (vDatabase.Count == 0)
+				PopulateDatabase();
+
+			int[] visitors = vDatabase.Where(x => x.Value.Invoke()).Select(x => x.Key).ToArray();
+			if (visitors.Length != 0)
+			{
+				int type = visitors[Main.rand.Next(visitors.Length)];
+				if (NPC.AnyNPCs(type))
+					return; //Don't spawn a duplicate
+
+				var position = GetSpawnPosition();
+				var npc = NPC.NewNPCDirect(Entity.GetSource_TownSpawn(), position, type);
+
+				if (Main.netMode == NetmodeID.SinglePlayer)
+					Main.NewText(Language.GetTextValue("Announcement.HasArrived", npc.FullName), 50, 125);
+				else if (Main.netMode == NetmodeID.Server)
+					ChatHelper.BroadcastChatMessage(NetworkText.FromKey("Announcement.HasArrived", npc.GetFullNetName()), new Color(50, 125, 255));
+
+				TravelerSpawned = true;
+			}
+		}
+
+		static Vector2 GetSpawnPosition()
+		{
+			List<NPC> townNPCs = [];
+			foreach (var npc in Main.ActiveNPCs)
+			{
+				if (npc.townNPC && !npc.homeless && npc.type != NPCID.OldMan)
+					townNPCs.Add(npc);
+			}
+
+			if (townNPCs.Count == 0)
+				return new Vector2(Main.spawnTileX, Main.spawnTileY - 1).ToWorldCoordinates();
+
+			return townNPCs[Main.rand.Next(townNPCs.Count)].Center;
+		}
+	}
+
+	private static void TryDespawn()
+	{
+		if (!Main.dayTime || Main.time > 48600.0)
+		{
+			foreach (var npc in Main.ActiveNPCs)
+			{
+				if (vDatabase.ContainsKey(npc.type) && !WorldGen.PlayerLOS((int)(npc.Center.X / 16), (int)(npc.Center.Y / 16)))
+				{
+					DespawnNPC(npc);
+					TravelerSpawned = false;
+
+					break;
+				}
+			}
+		}
+
+		static void DespawnNPC(NPC npc)
+		{
+			if (Main.netMode == NetmodeID.SinglePlayer)
+				Main.NewText(Lang.misc[35].Format(npc.FullName), 50, 125);
+			else if (Main.netMode == NetmodeID.Server)
+				ChatHelper.BroadcastChatMessage(NetworkText.FromKey(Lang.misc[35].Key, npc.GetFullNetName()), new Color(50, 125, 255));
+
+			npc.active = false;
+			npc.netSkip = -1;
+			npc.life = 0;
+
+			if (Main.netMode != NetmodeID.SinglePlayer)
+				NetMessage.SendData(MessageID.SyncNPC, -1, -1, null, npc.whoAmI);
+		}
+	}
+
+	private static void PopulateDatabase()
+	{
+		foreach (var npc in SpiritReforgedMod.Instance.GetContent<ModNPC>())
+		{
+			if (npc is ITravelNPC v)
+				vDatabase.Add(npc.Type, v.CanSpawnTraveler);
+		}
+	}
+}

--- a/Content/Forest/Misc/Cartographer.cs
+++ b/Content/Forest/Misc/Cartographer.cs
@@ -14,7 +14,7 @@ using SpiritReforged.Common.ModCompat;
 
 namespace SpiritReforged.Content.Forest.Misc;
 
-public class Cartographer : WorldNPC
+public class Cartographer : WorldNPC, ITravelNPC
 {
 	protected override bool CloneNewInstances => true;
 
@@ -162,13 +162,24 @@ public class Cartographer : WorldNPC
 		float multiplier = MathHelper.Lerp(1.75f, .5f, spawnInfo.Player.GetModPlayer<PinPlayer>().PinProgress) * (Main.hardMode ? .6f : 1f);
 
 		if (spawnInfo.SpawnTileY > Main.worldSurface && spawnInfo.SpawnTileY < Main.UnderworldLayer && !spawnInfo.Player.ZoneEvil())
-			return .00018f * multiplier; //Rarely spawn in caves above underworld height
+			return .00023f * multiplier; //Rarely spawn in caves above underworld height
 
 		if ((spawnInfo.Player.InModBiome<SavannaBiome>() || spawnInfo.Player.ZoneDesert || spawnInfo.Player.ZoneJungle || OuterThirds(spawnInfo.SpawnTileX) && spawnInfo.Player.InZonePurity() && !spawnInfo.Player.ZoneSkyHeight) && Main.dayTime)
-			return .0019f * multiplier; //Spawn most commonly in the Savanna, Desert, Jungle, and outer thirds of the Forest during the day
+			return .0024f * multiplier; //Spawn most commonly in the Savanna, Desert, Jungle, and outer thirds of the Forest during the day
 
 		return 0;
 
 		static bool OuterThirds(int x) => x < Main.maxTilesX / 3 || x > Main.maxTilesX - Main.maxTilesY / 3;
+	}
+
+	public bool CanSpawnTraveler()
+	{
+		foreach (var p in Main.ActivePlayers)
+		{
+			if (p.TryGetModPlayer(out PinPlayer pinPl) && pinPl.PinProgress != 0)
+				return true;
+		}
+
+		return false;
 	}
 }

--- a/Content/Forest/Misc/Hiker.cs
+++ b/Content/Forest/Misc/Hiker.cs
@@ -269,10 +269,10 @@ public class Hiker : WorldNPC
 		if (SpawnedToday || spawnInfo.Invasion || spawnInfo.Water)
 			return 0; //Never spawn during an invasion, in water or if already spawned that day
 
-		float multiplier = Main.hardMode ? .5f : ((NPC.downedBoss1 || NPC.downedSlimeKing) ? 1f : 2f);
+		float multiplier = Main.hardMode ? .5f : ((NPC.downedBoss1 || NPC.downedSlimeKing) ? 1f : 2f); //Double the rate pre-boss, and halve it in hardmode
 
 		if ((spawnInfo.Player.ZoneSnow || InnerThird(spawnInfo.SpawnTileX) && spawnInfo.Player.InZonePurity()) && spawnInfo.Player.ZoneOverworldHeight && Main.dayTime)
-			return .0019f * multiplier; //Spawn most commonly in the Snow and inner thirds of the Forest during the day
+			return .0024f * multiplier; //Spawn most commonly in the Snow and inner thirds of the Forest during the day
 
 		return 0;
 


### PR DESCRIPTION
- Adds a system for handling traveling NPCs
- Makes the Cartographer randomly appear like the traveling merchant when any player owns a pin
- Increased Hiker and Cartographer base spawn rates by 25%