### PR TITLE
Bomb cannon tweaks

### DIFF
--- a/Common/PrimitiveRendering/Trail_Components/ITrailColor.cs
+++ b/Common/PrimitiveRendering/Trail_Components/ITrailColor.cs
@@ -1,4 +1,6 @@
-﻿namespace SpiritReforged.Common.PrimitiveRendering.Trail_Components;
+﻿using SpiritReforged.Common.Easing;
+
+namespace SpiritReforged.Common.PrimitiveRendering.Trail_Components;
 
 public interface ITrailColor
 {
@@ -10,11 +12,14 @@ public class GradientTrail(Color start, Color end) : ITrailColor
 {
 	private Color _startColour = start;
 	private Color _endColour = end;
+	private EaseFunction _easing = EaseFunction.Linear;
+
+	public GradientTrail(Color start, Color end, EaseFunction easing) : this(start, end) => _easing = easing;
 
 	public Color GetColourAt(float distanceFromStart, float trailLength, List<Vector2> points, Vector2 curPoint)
 	{
 		float progress = distanceFromStart / trailLength;
-		return Color.Lerp(_startColour, _endColour, progress) * (1f - progress);
+		return Color.Lerp(_startColour, _endColour, _easing.Ease(progress)) * (1f - progress);
 	}
 }
 

--- a/Common/ProjectileCommon/Abstract/BombProjectile.cs
+++ b/Common/ProjectileCommon/Abstract/BombProjectile.cs
@@ -1,4 +1,5 @@
-﻿using Terraria.Audio;
+﻿using System.IO;
+using Terraria.Audio;
 
 namespace SpiritReforged.Common.ProjectileCommon.Abstract;
 
@@ -14,13 +15,15 @@ public abstract class BombProjectile : ModProjectile
 	/// <summary> Whether this bomb sticks to tiles according to <see cref="CheckStuck"/>. </summary>
 	public bool sticky;
 
-	private int _damage;
-	private float _knockback;
+	private bool _startedExplosion;
+
+	internal int _damage;
+	internal float _knockback;
 
 	/// <summary> Sets the timeLeft and timeLeftMax values for this projectile, for convenience. </summary>
-	protected void SetTimeLeft(int value) => Projectile.timeLeft = timeLeftMax = value;
+	public void SetTimeLeft(int value) => Projectile.timeLeft = timeLeftMax = value;
 	/// <summary> Sets the damage and knockback values for this projectile <b>specifically when exploding</b>. </summary>
-	protected void SetDamage(int damage, float knockback = 8f)
+	public void SetDamage(int damage, float knockback = 8f)
 	{
 		_damage = damage;
 		_knockback = knockback;
@@ -62,6 +65,12 @@ public abstract class BombProjectile : ModProjectile
 		{
 			DealingDamage = true;
 			Projectile.PrepareBombToBlow();
+
+			if (!_startedExplosion)
+			{
+				_startedExplosion = true;
+				StartExplosion();
+			}
 		}
 
 		Projectile.TryShimmerBounce();
@@ -90,6 +99,8 @@ public abstract class BombProjectile : ModProjectile
 			dust.noGravity = true;
 		}
 	}
+
+	public virtual void StartExplosion() { }
 
 	public override void OnKill(int timeLeft)
 	{
@@ -129,4 +140,8 @@ public abstract class BombProjectile : ModProjectile
 		Projectile.QuickDraw();
 		return false;
 	}
+
+	public override void SendExtraAI(BinaryWriter writer) => writer.Write(_startedExplosion);
+
+	public override void ReceiveExtraAI(BinaryReader reader) => _startedExplosion = reader.ReadBoolean();
 }

--- a/Content/Underground/Items/BombCannon.cs
+++ b/Content/Underground/Items/BombCannon.cs
@@ -25,6 +25,8 @@ namespace SpiritReforged.Content.Underground.Items;
 [AutoloadGlowmask("255,255,255")]
 public class BombCannon : ModItem
 {
+	public const float ContactDamagePercentage = 0.25f;
+
 	public override void SetStaticDefaults()
 	{
 		AmmoDatabase.RegisterAmmo(ItemID.Bomb, ItemID.Bomb, ItemID.StickyBomb, ItemID.BouncyBomb, ItemID.BombFish);
@@ -34,7 +36,7 @@ public class BombCannon : ModItem
 	public override void SetDefaults()
 	{
 		Item.DamageType = DamageClass.Ranged;
-		Item.damage = 60;
+		Item.damage = 80;
 		Item.width = 44;
 		Item.height = 48;
 		Item.useTime = Item.useAnimation = 30;
@@ -60,6 +62,17 @@ public class BombCannon : ModItem
 	}
 
 	public override bool CanConsumeAmmo(Item ammo, Player player) => !player.channel; //Ammo consumption happens in BombCannonHeld
+
+	public override void ModifyTooltips(List<TooltipLine> tooltips)
+	{
+		StatModifier rangedStat = Main.LocalPlayer.GetTotalDamage(DamageClass.Ranged);
+
+		foreach (TooltipLine line in tooltips)
+		{
+			if (line.Mod == "Terraria" && line.Name == "Damage") //Replace the vanilla text with our own
+				line.Text = $"{(int)rangedStat.ApplyTo(Item.damage * ContactDamagePercentage)}-{(int)rangedStat.ApplyTo(Item.damage)}" + Language.GetText("LegacyTooltip.3");
+		}
+	}
 }
 
 [AutoloadGlowmask("255,255,255", false)]
@@ -300,7 +313,7 @@ internal class BombCannonShot : BombProjectile, ITrailProjectile
 					{
 						Player owner = Main.player[Projectile.owner];
 						owner.ApplyDamageToNPC(npc,
-								   (int)owner.GetTotalDamage<RangedDamageClass>().ApplyTo(DamageModifier * _damage / 4f),
+								   (int)owner.GetTotalDamage<RangedDamageClass>().ApplyTo(DamageModifier * _damage * BombCannon.ContactDamagePercentage),
 								   Projectile.knockBack,
 								   Projectile.velocity.X > 0 ? 1 : -1,
 								   Main.rand.Next(100) < Projectile.CritChance,

--- a/Content/Underground/Items/BombCannon.cs
+++ b/Content/Underground/Items/BombCannon.cs
@@ -27,9 +27,13 @@ public class BombCannon : ModItem
 {
 	public const float ContactDamagePercentage = 0.25f;
 
+	public static int[] AmmoBombIDs = [ItemID.Bomb, ItemID.StickyBomb, ItemID.BouncyBomb, ItemID.BombFish];
+	public static int[] StickyBombProjIDs = [ProjectileID.BouncyBomb, ModContent.ProjectileType<BombBouncy>()];
+	public static int[] BouncyBombProjIDs = [ProjectileID.StickyBomb, ModContent.ProjectileType<BombSticky>(), ProjectileID.BombFish, ModContent.ProjectileType<BombFish>()];
+
 	public override void SetStaticDefaults()
 	{
-		AmmoDatabase.RegisterAmmo(ItemID.Bomb, ItemID.Bomb, ItemID.StickyBomb, ItemID.BouncyBomb, ItemID.BombFish);
+		AmmoDatabase.RegisterAmmo(ItemID.Bomb, AmmoBombIDs);
 		NPCShopHelper.AddEntry(new NPCShopHelper.ConditionalEntry((shop) => shop.NpcType == NPCID.Demolitionist, new NPCShop.Entry(Type, Condition.DownedEarlygameBoss)));
 	}
 
@@ -180,15 +184,13 @@ internal class BombCannonHeld : ModProjectile
 		if (Projectile.owner == Main.myPlayer)
 		{
 			var velocity = Projectile.velocity * Progress;
-			int[] bouncyBombs = [ProjectileID.BouncyBomb, ModContent.ProjectileType<BombBouncy>()];
-			int[] stickyBombs = [ProjectileID.StickyBomb, ModContent.ProjectileType<BombSticky>(), ProjectileID.BombFish, ModContent.ProjectileType<BombFish>()];
 			PreNewProjectile.New(Projectile.GetSource_FromAI(), Projectile.Center, Projectile.velocity, ModContent.ProjectileType<BombCannonShot>(), 0, Projectile.knockBack, Projectile.owner, ShootType, 1, preSpawnAction: delegate (Projectile p)
 			{
 				p.timeLeft = (int)(p.timeLeft * (1f - Progress));
 
 				var bomb = p.ModProjectile as BombCannonShot;
-				bomb.Bouncy = bouncyBombs.Contains(ShootType);
-				bomb.sticky = stickyBombs.Contains(ShootType);
+				bomb.Bouncy = BombCannon.BouncyBombProjIDs.Contains(ShootType);
+				bomb.sticky = BombCannon.StickyBombProjIDs.Contains(ShootType);
 				bomb.SetDamage(Projectile.damage);
 
 				if(Main.player[Projectile.owner].HasAccessory<BoomShroom>())

--- a/Content/Underground/Items/BombCannon.cs
+++ b/Content/Underground/Items/BombCannon.cs
@@ -1,16 +1,24 @@
+using SpiritReforged.Common.Easing;
 using SpiritReforged.Common.ItemCommon;
+using SpiritReforged.Common.MathHelpers;
 using SpiritReforged.Common.Misc;
 using SpiritReforged.Common.NPCCommon;
 using SpiritReforged.Common.Particle;
 using SpiritReforged.Common.PlayerCommon;
+using SpiritReforged.Common.PrimitiveRendering;
+using SpiritReforged.Common.PrimitiveRendering.Trail_Components;
 using SpiritReforged.Common.ProjectileCommon;
+using SpiritReforged.Common.ProjectileCommon.Abstract;
+using SpiritReforged.Common.Visuals;
 using SpiritReforged.Common.Visuals.Glowmasks;
 using SpiritReforged.Content.Particles;
 using SpiritReforged.Content.Underground.Items.BigBombs;
-using System.IO;
+using System.Linq;
 using Terraria.Audio;
 using Terraria.DataStructures;
-using Terraria.ModLoader.IO;
+using static SpiritReforged.Common.Easing.EaseFunction;
+using static Microsoft.Xna.Framework.Color;
+using static Microsoft.Xna.Framework.MathHelper;
 
 namespace SpiritReforged.Content.Underground.Items;
 
@@ -25,6 +33,8 @@ public class BombCannon : ModItem
 
 	public override void SetDefaults()
 	{
+		Item.DamageType = DamageClass.Ranged;
+		Item.damage = 60;
 		Item.width = 44;
 		Item.height = 48;
 		Item.useTime = Item.useAnimation = 30;
@@ -45,7 +55,7 @@ public class BombCannon : ModItem
 		if (player.HasAccessory<BoomShroom>())
 			type = BoomShroomPlayer.MakeLarge(type);
 
-		Projectile.NewProjectile(source, position, velocity, Item.shoot, 0, 0, player.whoAmI, type);
+		Projectile.NewProjectile(source, position, velocity, Item.shoot, damage, knockback, player.whoAmI, type, 0, velocity.Length());
 		return false;
 	}
 
@@ -64,6 +74,7 @@ internal class BombCannonHeld : ModProjectile
 	}
 
 	public ref float Charge => ref Projectile.ai[1];
+	public ref float StoredVelocity => ref Projectile.ai[2];
 	public float Progress => (float)Charge / ChargeTimeMax;
 
 	public override string Texture => ModContent.GetInstance<BombCannon>().Texture;
@@ -96,22 +107,25 @@ internal class BombCannonHeld : ModProjectile
 
 			if (owner.whoAmI == Main.myPlayer) //Adjust to cursor direction
 			{
-				Projectile.velocity = (Vector2.UnitX * Projectile.velocity.Length()).RotatedBy(owner.AngleTo(Main.MouseWorld));
+				float speed = StoredVelocity;
+				speed *= 1 + Progress / 3;
+
+				Vector2 shootDirection = owner.GetArcVel(Main.MouseWorld, 0.2f, speed);
+				Projectile.velocity = shootDirection;
 				Projectile.netUpdate = true;
 			}
 
 			int limit = (int)(ChargeTimeMax / 3f);
 			if ((int)Charge % limit == limit - 1)
+			{
 				SoundEngine.PlaySound(SoundID.MenuTick with { Pitch = Progress * .5f }, Projectile.Center);
 
-			if (Charge == ChargeTimeMax / 3)
-			{
 				var start = Projectile.Center + new Vector2(8, 10 * Projectile.direction).RotatedBy(Projectile.rotation);
 
-				ParticleHandler.SpawnParticle(new ImpactLine(start, Vector2.Zero, Color.Red.Additive(), new Vector2(1, 2), 10, Projectile));
-				ParticleHandler.SpawnParticle(new ImpactLine(start, Vector2.Zero, (Color.White * .3f).Additive(), new Vector2(1, 2) * .7f, 10, Projectile));
+				ParticleHandler.SpawnParticle(new ImpactLine(start, Vector2.Zero, Red.Additive(), new Vector2(1, 2), 10, Projectile));
+				ParticleHandler.SpawnParticle(new ImpactLine(start, Vector2.Zero, (White * .3f).Additive(), new Vector2(1, 2) * .7f, 10, Projectile));
 
-				ParticleHandler.SpawnParticle(new PulseCircle(Projectile, Color.Red, .1f, 50, 15, Common.Easing.EaseFunction.EaseQuadOut, start));
+				ParticleHandler.SpawnParticle(new PulseCircle(Projectile, Red, .1f, 50, 15, EaseQuadOut, start));
 			}
 
 			Charge = Math.Min(Charge + 1, ChargeTimeMax);
@@ -153,10 +167,25 @@ internal class BombCannonHeld : ModProjectile
 		if (Projectile.owner == Main.myPlayer)
 		{
 			var velocity = Projectile.velocity * Progress;
-			PreNewProjectile.New(Projectile.GetSource_FromAI(), Projectile.Center, velocity, ShootType, owner: Projectile.owner, preSpawnAction: delegate (Projectile p)
+			int[] bouncyBombs = [ProjectileID.BouncyBomb, ModContent.ProjectileType<BombBouncy>()];
+			int[] stickyBombs = [ProjectileID.StickyBomb, ModContent.ProjectileType<BombSticky>(), ProjectileID.BombFish, ModContent.ProjectileType<BombFish>()];
+			PreNewProjectile.New(Projectile.GetSource_FromAI(), Projectile.Center, Projectile.velocity, ModContent.ProjectileType<BombCannonShot>(), 0, Projectile.knockBack, Projectile.owner, ShootType, 1, preSpawnAction: delegate (Projectile p)
 			{
 				p.timeLeft = (int)(p.timeLeft * (1f - Progress));
-				p.GetGlobalProjectile<NullBombProjectile>().noExplode = true;
+
+				var bomb = p.ModProjectile as BombCannonShot;
+				bomb.Bouncy = bouncyBombs.Contains(ShootType);
+				bomb.sticky = stickyBombs.Contains(ShootType);
+				bomb.SetDamage(Projectile.damage);
+
+				if(Main.player[Projectile.owner].HasAccessory<BoomShroom>())
+				{
+					bomb.BoomShroom = true;
+					bomb.area = 15;
+					p.Size = new Vector2(32);
+					bomb.SetDamage((int)(Projectile.damage * 1.5f));
+					p.scale = 0;
+				}
 			});
 		}
 
@@ -166,15 +195,15 @@ internal class BombCannonHeld : ModProjectile
 		for (int i = 0; i < 12; i++)
 		{
 			float mag = Main.rand.NextFloat();
-			Dust.NewDustPerfect(muzzle, DustID.Torch, (unit * 10f * mag).RotatedByRandom(.5f * (1f - mag)), Scale: Main.rand.NextFloat(.5f, 2f)).noGravity = true;
+			Dust.NewDustPerfect(muzzle, DustID.GemRuby, (unit * 10f * mag).RotatedByRandom(.5f * (1f - mag)), Scale: Main.rand.NextFloat(.5f, 2f)).noGravity = true;
 
 			if (Main.rand.NextBool())
 			{
 				float scale = Main.rand.NextFloat(.5f, 1f);
 				var velocity = (unit * Main.rand.NextFloat(3f)).RotatedByRandom(.5f);
 
-				ParticleHandler.SpawnParticle(new GlowParticle(muzzle, velocity, Color.OrangeRed, scale, 20, 5));
-				ParticleHandler.SpawnParticle(new GlowParticle(muzzle, velocity, Color.White, scale * .5f, 20, 5));
+				ParticleHandler.SpawnParticle(new GlowParticle(muzzle, velocity, Red, scale, 20, 5));
+				ParticleHandler.SpawnParticle(new GlowParticle(muzzle, velocity, White, scale * .5f, 20, 5));
 			}
 		}
 
@@ -198,28 +227,240 @@ internal class BombCannonHeld : ModProjectile
 		var glowFrame = new Rectangle(0, 0, width, texture.Height);
 
 		Main.EntitySpriteDraw(texture, position, null, Projectile.GetAlpha(lightColor), Projectile.rotation, texture.Size() / 2, Projectile.scale, effects);
-		Main.EntitySpriteDraw(glowmask, position, glowFrame, Projectile.GetAlpha(Color.White), Projectile.rotation, texture.Size() / 2, Projectile.scale, effects);
+		Main.EntitySpriteDraw(glowmask, position, glowFrame, Projectile.GetAlpha(White), Projectile.rotation, texture.Size() / 2, Projectile.scale, effects);
 		return false;
 	}
 }
 
-/// <summary> Prevents <see cref="Projectile.ExplodeTiles"/> from exploding tiles when <see cref="noExplode"/> is <see cref="true"/>. </summary>
-internal class NullBombProjectile : GlobalProjectile
+internal class BombCannonShot : BombProjectile, ITrailProjectile
 {
-	public override bool InstancePerEntity => true;
-	public override bool AppliesToEntity(Projectile entity, bool lateInstantiation) => ProjectileID.Sets.Explosive[entity.type];
+	internal bool Bouncy { get; set; } = false;
 
-	public bool noExplode;
+	internal bool BoomShroom { get; set; } = false;
 
-	public override void Load() => On_Projectile.ExplodeTiles += PreventTileDamage;
-	private static void PreventTileDamage(On_Projectile.orig_ExplodeTiles orig, Projectile self, Vector2 compareSpot, int radius, int minI, int maxI, int minJ, int maxJ, bool wallSplode)
+	/// <summary>
+	/// The original projectile this one is mimicking the sprite and behavior of.
+	/// </summary>
+	internal int CopyProj { get => (int)Projectile.ai[0]; set => Projectile.ai[0] = value; }
+
+	/// <summary>
+	/// Tracks how much the contact damage of the projectile should be reduced with each enemy struck.
+	/// </summary>
+	internal ref float DamageModifier => ref Projectile.ai[1];
+
+	public override string Texture => ModContent.GetInstance<BombCannon>().Texture;
+
+	public override void SetDefaults()
 	{
-		if (self.TryGetGlobalProjectile(out NullBombProjectile n) && n.noExplode)
-			return;
-
-		orig(self, compareSpot, radius, minI, maxI, minJ, maxJ, wallSplode);
+		base.SetDefaults();
+		Projectile.DamageType = DamageClass.Ranged;
 	}
 
-	public override void SendExtraAI(Projectile projectile, BitWriter bitWriter, BinaryWriter binaryWriter) => bitWriter.WriteBit(noExplode);
-	public override void ReceiveExtraAI(Projectile projectile, BitReader bitReader, BinaryReader binaryReader) => noExplode = bitReader.ReadBit();
+	public void DoTrailCreation(TrailManager tM)
+	{
+		float baseWidth = BoomShroom ? 60 : 40;
+		float baseLength = BoomShroom ? 360 : 240;
+
+		ITrailCap tCap = new RoundCap();
+		ITrailPosition tPos = new DefaultTrailPosition();
+		ITrailShader tShader = new ImageShader(AssetLoader.LoadedTextures["GlowTrail"].Value, Vector2.One);
+
+		tM.CreateTrail(Projectile, new GradientTrail(Red.Additive(150) * 0.5f, Transparent, EaseQuarticOut), tCap, tPos, baseWidth * 2, baseLength, tShader);
+		tM.CreateTrail(Projectile, new GradientTrail(Lerp(Red, Pink, 0.25f).Additive(150) * 0.75f, Transparent, EaseQuarticOut), tCap, tPos, baseWidth * 1.5f, baseLength, tShader);
+		tM.CreateTrail(Projectile, new GradientTrail(Pink.Additive(), Transparent, EaseQuarticOut), tCap, tPos, baseWidth, baseLength, tShader); 
+
+		tM.CreateTrail(Projectile, new LightColorTrail(White.Additive() * 0.25f, Transparent), tCap, tPos, baseWidth, baseLength, new DefaultShader());
+	}
+
+	public override void AI()
+	{
+		base.AI();
+
+		if (!DealingDamage)
+		{
+			if(BoomShroom)
+			{
+				float oldScale = Projectile.scale; //Resize logic
+				Projectile.scale = Math.Min(Projectile.scale + .15f, 1);
+
+				if (Projectile.scale != oldScale)
+				{
+					int size = (int)Math.Max(32 * Projectile.scale, 2);
+					Projectile.Resize(size, size);
+				}
+			}
+
+			//Hacky fake collision logic, due to the explosive projectile set seeming to always make bombs explode instantly on hit
+			//Might be missing something to ensure proper interactions with accessories and other on hit effects?
+			foreach (NPC npc in Main.ActiveNPCs)
+			{
+				if (npc.Hitbox.Intersects(Projectile.Hitbox))
+				{
+					if(Projectile.localNPCImmunity[npc.whoAmI] == 0)
+					{
+						Player owner = Main.player[Projectile.owner];
+						owner.ApplyDamageToNPC(npc,
+								   (int)owner.GetTotalDamage<RangedDamageClass>().ApplyTo(DamageModifier * _damage / 4f),
+								   Projectile.knockBack,
+								   Projectile.velocity.X > 0 ? 1 : -1,
+								   Main.rand.Next(100) < Projectile.CritChance,
+								   DamageClass.Ranged,
+								   true);
+
+						DamageModifier *= 0.8f;
+						Projectile.localNPCImmunity[npc.whoAmI] = -1;
+					}
+				}
+			}
+		}
+
+		if (Projectile.velocity == Vector2.Zero && Projectile.oldVelocity == Vector2.Zero)
+			TrailManager.TryTrailKill(Projectile);
+	}
+
+	public override void StartExplosion() => Projectile.ResetLocalNPCHitImmunity();
+
+	public override void FuseVisuals()
+	{
+		if (Main.rand.NextBool())
+		{
+			var position = Projectile.Center - (new Vector2(0, Projectile.height / 2 + 10) * Projectile.scale).RotatedBy(Projectile.rotation);
+
+			var dust = Dust.NewDustPerfect(position, DustID.Smoke, Main.rand.NextVector2Unit(), 100);
+			dust.scale = 0.1f + Main.rand.NextFloat(0.5f);
+			dust.fadeIn = 1.5f + Main.rand.NextFloat(0.5f);
+			dust.noGravity = true;
+
+			dust = Dust.NewDustPerfect(position, DustID.GemRuby, Main.rand.NextVector2Unit(), 100);
+			dust.scale = 1f + Main.rand.NextFloat(0.5f);
+			dust.noGravity = true;
+		}
+	}
+
+	public override bool OnTileCollide(Vector2 oldVelocity)
+	{
+		if(Bouncy)
+		{
+			Projectile.Bounce(oldVelocity);
+			return false;
+		}
+
+		else if(!sticky)
+		{
+			Projectile.Bounce(oldVelocity, 0.3f);
+
+			float rotationDifference = WrapAngle(oldVelocity.ToRotation() - Projectile.velocity.ToRotation());
+			rotationDifference = Math.Abs(rotationDifference);
+
+			//Create a new trail to prevent the vertex strip from freaking out over movements in opposite directions
+			if(rotationDifference > PiOver2 * 1.5f)
+			{
+				TrailManager.TryTrailKill(Projectile);
+
+				if (Projectile.velocity.Length() > 1)
+					TrailManager.ManualTrailSpawn(Projectile);
+			}
+
+			return false;
+		}
+
+		return base.OnTileCollide(oldVelocity);
+	}
+
+	public override void OnKill(int timeLeft)
+	{
+		if (Main.dedServ)
+			return;
+
+		SoundEngine.PlaySound(SoundID.Item14, Projectile.Center);
+		if(BoomShroom)
+			SoundEngine.PlaySound(SoundID.DD2_ExplosiveTrapExplode, Projectile.Center);
+
+		//Particle circles showing radius of explosion
+		var ease = new PolynomialEase((float x) => (float)(0.5 + 0.5 * Math.Pow(x, 0.5)));
+		var stretch = new Vector2(2, 1);
+
+		ParticleHandler.SpawnParticle(new TexturedPulseCircle(Projectile.Center, Lerp(Pink, Red, 0.25f).Additive(150), Red, 1f, 30 * area, 20, "Star2", stretch, ease)
+		{
+			Angle = Main.rand.NextFloatDirection()
+		});
+
+		ParticleHandler.SpawnParticle(new TexturedPulseCircle(Projectile.Center, Lerp(Pink, Red, 0.5f).Additive(150), Red, .5f, 40 * area, 20, "Star2", stretch, ease)
+		{
+			Angle = Main.rand.NextFloatDirection()
+		});
+
+		//Burst of light in the center
+		float lightburstRotation = Main.rand.NextFloatDirection();
+		for(int i = 0; i < 3; i++)
+			ParticleHandler.SpawnParticle(new DissipatingImage(Projectile.Center, Lerp(Pink, Red, 0.5f).Additive(), Main.rand.NextFloatDirection(), 0.02f * area, 0, "GodrayCircle", 15));
+
+		const int time = 5;
+		ParticleHandler.SpawnParticle(new ImpactLinePrim(Projectile.Center, Vector2.Zero, Red.Additive(), new Vector2(0.2f, 1f) * area, time, 1));
+		ParticleHandler.SpawnParticle(new ImpactLinePrim(Projectile.Center, Vector2.Zero, Pink.Additive(), new Vector2(0.1f, 1f) * area, time, 1));
+
+		//Glowy particles coming from the center
+		for (int i = 0; i < area * 2; i++)
+		{
+			float magnitude = Main.rand.NextFloat(0.25f, 1);
+
+			var color = Red.Additive();
+			var velocity = Main.rand.NextVector2Unit() * magnitude * 4;
+			float scale = (1f - magnitude) * 0.3f * area;
+			int lifeTime = Main.rand.Next(25, 35);
+
+			static void DelegateAction(Particle p) => p.Velocity *= 0.97f;
+
+			ParticleHandler.SpawnParticle(new GlowParticle(Projectile.Center + velocity * 10, velocity, color, scale, 30, 3, DelegateAction));
+			ParticleHandler.SpawnParticle(new GlowParticle(Projectile.Center + velocity * 10, velocity, White.Additive(), scale * .5f, lifeTime, 3, DelegateAction));
+
+			var d = Dust.NewDustPerfect(Projectile.Center + Main.rand.NextVector2Unit() * Main.rand.NextFloat(16f * area), DustID.GemRuby, Scale: Main.rand.NextFloat() + .5f);
+			d.noGravity = true;
+		}
+	}
+
+	public override bool PreDraw(ref Color lightColor)
+	{
+		Texture2D copyTexture = TextureAssets.Projectile[CopyProj].Value;
+		Texture2D solid = TextureColorCache.ColorSolid(copyTexture, Red.Additive(150));
+		Vector2 origin = copyTexture.Size() / 2;
+		origin.Y += 4;
+		float lerp = GetLerp();
+		float scale = Projectile.scale + lerp * .1f;
+
+		Rectangle drawRect = copyTexture.Bounds;
+
+		//Fix drawing for bomb fish specifically and make it animate instead of changing scale
+		if (CopyProj == ProjectileID.BombFish)
+		{
+			drawRect.Height /= 4;
+			origin.Y = drawRect.Height/2 + 4;
+			int frame = lerp switch
+			{
+				< 0.25f => 0,
+				< 0.5f => 1,
+				< 0.75f => 2,
+				_ => 3
+			};
+
+			drawRect.Y = drawRect.Height * frame;
+			scale = 1;
+		}
+
+		Main.EntitySpriteDraw(solid, Projectile.Center - Main.screenPosition, drawRect, White, Projectile.rotation, origin, scale * 1.1f, SpriteEffects.None);
+
+		Main.EntitySpriteDraw(copyTexture, Projectile.Center - Main.screenPosition, drawRect, Projectile.GetAlpha(lightColor), Projectile.rotation, origin, scale, SpriteEffects.None);
+
+		var color = Projectile.GetAlpha(Red.Additive(150)) * lerp * 2;
+		Main.EntitySpriteDraw(solid, Projectile.Center - Main.screenPosition, drawRect, color, Projectile.rotation, origin, scale, SpriteEffects.None);
+		return false;
+	}
+
+	public float GetLerp()
+	{
+		float progress = 1f - (float)Projectile.timeLeft / timeLeftMax;
+
+		int numFlashes = 9;
+		return EaseCircularIn.Ease((float)Math.Sin(EaseCircularIn.Ease(progress) * numFlashes * Pi));
+	}
 }

--- a/Localization/en-US/Mods.SpiritReforged.Projectiles.hjson
+++ b/Localization/en-US/Mods.SpiritReforged.Projectiles.hjson
@@ -34,3 +34,4 @@ Shockwave.DisplayName: Shockwave
 EnergizedShockwave.DisplayName: Energized Shockwave
 RollingBowlder.DisplayName: Rolling Bowlder
 Firespike.DisplayName: Firespike
+BombCannonShot.DisplayName: Bomb Cannon Shot

--- a/Localization/pt-BR/Mods.SpiritReforged.Projectiles.hjson
+++ b/Localization/pt-BR/Mods.SpiritReforged.Projectiles.hjson
@@ -34,3 +34,4 @@ FallingBaobabFruit.DisplayName: Fruto de Baobá Caído
 // EnergizedShockwave.DisplayName: Energized Shockwave
 // RollingBowlder.DisplayName: Rolling Bowlder
 // Firespike.DisplayName: Firespike
+// BombCannonShot.DisplayName: Bomb Cannon Shot

--- a/Localization/ru-RU/Mods.SpiritReforged.Projectiles.hjson
+++ b/Localization/ru-RU/Mods.SpiritReforged.Projectiles.hjson
@@ -34,3 +34,4 @@ FallingBaobabFruit.DisplayName: Падающий плод баобаба
 // EnergizedShockwave.DisplayName: Energized Shockwave
 // RollingBowlder.DisplayName: Rolling Bowlder
 // Firespike.DisplayName: Firespike
+// BombCannonShot.DisplayName: Bomb Cannon Shot

--- a/Localization/zh-Hans/Mods.SpiritReforged.Projectiles.hjson
+++ b/Localization/zh-Hans/Mods.SpiritReforged.Projectiles.hjson
@@ -34,3 +34,4 @@ FallingBaobabFruit.DisplayName: 掉落的面包树果实
 // EnergizedShockwave.DisplayName: Energized Shockwave
 // RollingBowlder.DisplayName: Rolling Bowlder
 // Firespike.DisplayName: Firespike
+// BombCannonShot.DisplayName: Bomb Cannon Shot


### PR DESCRIPTION
Greatly adjusts how bomb cannon works under the hood to allow for unique visuals, and the bomb doing contact damage, with nerfed explosion damage to compensate

Changes bomb cannon to use arc velocity calculation, and increases shot speed at low charge to be far more consistent

Bomb cannon is now classified as a ranged weapon and displays its damage range in the tooltip