### PR TITLE
add timber to drywood pickup, benched to either bench craft, cleanup

### DIFF
--- a/Common/Misc/AchievementGlobalItem.cs
+++ b/Common/Misc/AchievementGlobalItem.cs
@@ -1,0 +1,56 @@
+﻿using SpiritReforged.Common.ItemCommon;
+using SpiritReforged.Common.TileCommon;
+using SpiritReforged.Content.Ocean.Tiles.Furniture;
+using SpiritReforged.Content.Savanna.Tiles;
+using SpiritReforged.Content.Savanna.Tiles.Furniture;
+using System.Runtime.CompilerServices;
+using Terraria.Achievements;
+using Terraria.DataStructures;
+
+namespace SpiritReforged.Common.Misc;
+
+internal class AchievementModifications : GlobalItem
+{
+	// God forbid this game is normal. Because of how achievements are programmed, namely a lot of delegates, and how mod loading works,
+	// I didn't want to directly modify the achivements (since they're saved as json and/or into achievements.dat at some point) which
+	// could cause issues I don't want to debug - the achievements also make use of delegates often enough to where I'd be concerned
+	// about variable capturing making these edits inconsistent/hard to debug. I didn't want to expand ItemID.Sets.Workbenches because
+	// we're literally 1 day off of the Named ID Sets coming into tMod and that'd be much nicer.
+	// Instead, I did this hacky workaround.
+	// It works, so too bad.
+
+	public override bool OnPickup(Item item, Player player)
+	{
+		// Add the TIMBER achievement when picking up Drywood
+		if (item.type == ModContent.GetInstance<Drywood>().AutoItem().type)
+			CompleteAchievement(Main.Achievements.GetAchievement("TIMBER"));
+
+		return true;
+	}
+
+	public override void OnCreated(Item item, ItemCreationContext context)
+	{
+		// Add the BENCHED achievement to crafting any Reforged workbench
+		if (context is RecipeItemCreationContext && (item.type == TileToItem<DriftwoodWorkBench>() || item.type == TileToItem<DrywoodWorkBench>()))
+			CompleteAchievement(Main.Achievements.GetAchievement("BENCHED"));
+	}
+
+	private static void CompleteAchievement(Achievement achievement)
+	{
+		ref int completedCount = ref GetCount(achievement);
+		completedCount = GetConditions(achievement).Count - 1;
+
+		CallComplete(achievement, null);
+	}
+
+	private static int TileToItem<T>() where T : ModTile, IAutoloadTileItem => ModContent.GetInstance<T>().AutoItem().type;
+
+	[UnsafeAccessor(UnsafeAccessorKind.Field, Name = "_completedCount")]
+	static extern ref int GetCount(Achievement achievement);
+
+	[UnsafeAccessor(UnsafeAccessorKind.Field, Name = "_conditions")]
+	static extern ref Dictionary<string, AchievementCondition> GetConditions(Achievement achievement);
+
+	[UnsafeAccessor(UnsafeAccessorKind.Method, Name = "OnConditionComplete")]
+	static extern void CallComplete(Achievement achievement, AchievementCondition cond);
+}

--- a/Common/SpiritSets.cs
+++ b/Common/SpiritSets.cs
@@ -3,6 +3,7 @@
 public static class SpiritSets
 {
 	internal static SetFactory TileFactory = new(TileLoader.TileCount, nameof(SpiritSets));
+
 	/// <summary> Whether this type converts into the provided type when mowed with a lawnmower. </summary>
 	public static readonly int[] Mowable = TileFactory.CreateIntSet();
 }

--- a/Common/TileCommon/IAutoloadTileItem.cs
+++ b/Common/TileCommon/IAutoloadTileItem.cs
@@ -13,6 +13,7 @@ public interface IAutoloadTileItem
 	public string Name { get; }
 	public string Texture { get; }
 
+	public void StaticItemDefaults(ModItem item) { }
 	public void SetItemDefaults(ModItem item) { }
 	public void AddItemRecipes(ModItem item) { }
 }
@@ -52,6 +53,8 @@ public class AutoloadedTileItem(string name, string texture, IAutoloadTileItem h
 		item._hooks = _hooks;
 		return item;
 	}
+
+	public override void SetStaticDefaults() => _hooks.StaticItemDefaults(this);
 
 	public override void SetDefaults()
 	{

--- a/Common/TileCommon/PresetTiles/Furniture/FurnitureTile.cs
+++ b/Common/TileCommon/PresetTiles/Furniture/FurnitureTile.cs
@@ -9,6 +9,7 @@ public abstract class FurnitureTile : ModTile, IAutoloadTileItem
 	/// <summary> The defining material in most furniture recipes. </summary>
 	public virtual int CoreMaterial => ItemID.None;
 
+	public virtual void StaticItemDefaults(ModItem item) { }
 	public virtual void SetItemDefaults(ModItem item) { }
 	public virtual void AddItemRecipes(ModItem item) { }
 

--- a/Common/WorldGeneration/Micropasses/CustomCaves.cs
+++ b/Common/WorldGeneration/Micropasses/CustomCaves.cs
@@ -46,7 +46,7 @@ internal class CustomCaves : ModSystem
 
 	private static void OverrideGenMound(On_WorldGen.orig_Mountinater orig, int i, int j)
 	{
-		var type = CaveEntranceType.Canyon;// (CaveEntranceType)WorldGen.genRand.Next((int)CaveEntranceType.Count);
+		var type = (CaveEntranceType)WorldGen.genRand.Next((int)CaveEntranceType.Count);
 		TypeByPosition.Add(new(i, j), type);
 
 		if (type == CaveEntranceType.Vanilla)


### PR DESCRIPTION
- Adds TIMBER achievement to picking up Drywood
- Adds BENCHED achievement to picking up either Reforged workbench
- Undid debug rate for caves which made every single one of them a canyon
- Added StaticItemDefaults for IAutoloadTileItem, unused because ItemID.Sets.Workbenches is dumb