### PR TITLE
Potstiary crossmod

### DIFF
--- a/Common/TileCommon/PresetTiles/PotTile.cs
+++ b/Common/TileCommon/PresetTiles/PotTile.cs
@@ -98,12 +98,14 @@ public abstract class PotTile : ModTile, IRecordTile, IAutoloadRubble
 		if (Autoloader.IsRubble(Type) || Generating)
 			return;
 
-		if (Main.netMode != NetmodeID.MultiplayerClient && this is ILootTile loot)
+		if (Main.netMode != NetmodeID.MultiplayerClient && RecordHandler.ActionByType.TryGetValue(Type, out var action))
 		{
 			var position = new Vector2(i, j).ToWorldCoordinates(16, 16);
-
 			var p = Main.player[Player.FindClosest(position, 0, 0)];
-			loot.AddLoot(TileObjectData.GetTileStyle(Main.tile[i, j])).Resolve(new Rectangle((int)position.X - 16, (int)position.Y - 16, 32, 32), p);
+			var loot = new LootTable();
+
+			action.Invoke(TileObjectData.GetTileStyle(Main.tile[i, j]), loot);
+			loot.Resolve(new Rectangle((int)position.X - 16, (int)position.Y - 16, 32, 32), p);
 		}
 
 		if (!Main.dedServ)

--- a/Common/TileCommon/PresetTiles/PotTile.cs
+++ b/Common/TileCommon/PresetTiles/PotTile.cs
@@ -98,15 +98,8 @@ public abstract class PotTile : ModTile, IRecordTile, IAutoloadRubble
 		if (Autoloader.IsRubble(Type) || Generating)
 			return;
 
-		if (Main.netMode != NetmodeID.MultiplayerClient && RecordHandler.ActionByType.TryGetValue(Type, out var action))
-		{
-			var position = new Vector2(i, j).ToWorldCoordinates(16, 16);
-			var p = Main.player[Player.FindClosest(position, 0, 0)];
-			var loot = new LootTable();
-
-			action.Invoke(TileObjectData.GetTileStyle(Main.tile[i, j]), loot);
-			loot.Resolve(new Rectangle((int)position.X - 16, (int)position.Y - 16, 32, 32), p);
-		}
+		if (Main.netMode != NetmodeID.MultiplayerClient)
+			LootTable.Resolve(i, j, Type, frameX, frameY); //Resolves the loot table, if any
 
 		if (!Main.dedServ)
 			DeathEffects(i, j, frameX, frameY);

--- a/Common/UI/PotCatalogue/CatalogueUI.InfoElements.cs
+++ b/Common/UI/PotCatalogue/CatalogueUI.InfoElements.cs
@@ -1,4 +1,5 @@
 ﻿using SpiritReforged.Common.UI.System;
+using SpiritReforged.Content.Underground.Pottery;
 using SpiritReforged.Content.Underground.Tiles;
 using Terraria.GameContent.ItemDropRules;
 
@@ -66,15 +67,16 @@ public partial class CatalogueUI : AutoUIState
 
 		_info.AddEntry(info);
 
-		//Loot table for ILootTiles
-		if (TileLoader.GetTile(Selected.record.type) is ILootTile loot)
+		//Loot tables for registered types
+		if (RecordHandler.ActionByType.TryGetValue(Selected.record.type, out var action))
 		{
-			var lootTable = loot.AddLoot(Selected.record.styles[0]);
+			var tableInst = new LootTable();
+			action.Invoke(Selected.record.styles[0], tableInst);
 
 			List<DropRateInfo> list = [];
 			DropRateInfoChainFeed ratesInfo = new(1f);
 
-			foreach (IItemDropRule item in lootTable.Get())
+			foreach (IItemDropRule item in tableInst.Get())
 				item.ReportDroprates(list, ratesInfo);
 
 			foreach (var rateInfo in list)

--- a/Content/Underground/Pottery/RecordHandler.cs
+++ b/Content/Underground/Pottery/RecordHandler.cs
@@ -12,6 +12,7 @@ public interface IRecordTile : INamedStyles
 
 public class RecordHandler : ModSystem
 {
+	public static readonly Dictionary<int, Action<int, ILoot>> ActionByType = [];
 	public static readonly HashSet<TileRecord> Records = [];
 
 	/// <summary> Checks whether the tile at the given coordinates corresponds to a record. </summary>
@@ -52,8 +53,59 @@ public class RecordHandler : ModSystem
 				continue;
 
 			foreach (var group in StyleDatabase.Groups[type])
+			{
 				r.AddRecord(type, group);
+
+				if (TileLoader.GetTile(type) is ILootTile loot)
+					ActionByType.TryAdd(type, loot.AddLoot); //Automatically register a loot table if applicable
+			}
 		}
+	}
+
+	public static bool ManualAddRecord(object[] args)
+	{
+		if (args.Length < 3)
+			throw new ArgumentException("AddPotstiaryRecord requires at least 3 parameters.");
+
+		if (args[0] is not int or ushort)
+			throw new ArgumentException("AddPotstiaryRecord parameter 0 should be an int or ushort.");
+
+		int type = (int)args[0];
+
+		if (args[1] is not int[] styles)
+			throw new ArgumentException("AddPotstiaryRecord parameter 1 should be an int[].");
+
+		if (args[2] is not string name)
+			throw new ArgumentException("AddPotstiaryRecord parameter 2 should be a string.");
+
+		var e = new TileRecord(name, type, styles);
+
+		if (args.Length > 3 && args[3] is byte rating)
+			e.AddRating(rating);
+
+		if (args.Length > 4 && args[4] is bool hidden && hidden == true)
+			e.Hide();
+
+		if (args.Length > 5) //Add a loot pool
+		{
+			if (args[5] is bool hasBasicLoot && hasBasicLoot == true)
+			{
+				ActionByType.Add(type, ModContent.GetInstance<Pots>().AddLoot);
+			}
+			else if (args[5] is Action<int, ILoot> dele)
+			{
+				ActionByType.Add(type, dele);
+			}
+		}
+
+		if (args.Length > 6 && args[6] is LocalizedText desc)
+			e.AddDescription(desc);
+
+		if (args.Length > 7 && args[7] is LocalizedText dispName)
+			e.AddDisplayName(dispName);
+
+		Records.Add(e);
+		return true;
 	}
 }
 

--- a/Content/Underground/Pottery/TileRecord.cs
+++ b/Content/Underground/Pottery/TileRecord.cs
@@ -55,7 +55,7 @@ public struct TileRecord
 
 	public readonly void DrawIcon(SpriteBatch spriteBatch, Vector2 position, Color color)
 	{
-		const int maxSize = 4;
+		const int maxSize = 5;
 
 		int tileStyle = styles[0];
 		var data = TileObjectData.GetTileData(type, 0);
@@ -72,17 +72,17 @@ public struct TileRecord
 		if (wrapLimit == 0)
 			wrapLimit = (data.RandomStyleRange == 0) ? 2000 : data.RandomStyleRange;
 
-		for (int x = 0; x < width; x++)
+		for (int x = 0; x < Math.Min(width, maxSize); x++)
 		{
-			for (int y = 0; y < height; y++)
+			for (int y = 0; y < Math.Min(height, maxSize); y++)
 			{
 				var start = FrameStart(x, y);
-				var source = new Rectangle(start.X, start.Y, 16, 16);
+				var source = new Rectangle(start.X, start.Y, data.CoordinateWidth, data.CoordinateHeights[y]);
 				source.Y += Main.tileFrame[type] * data.CoordinateFullHeight; //Animation
 
-				if (x == maxSize)
+				if (x == maxSize - 1)
 					source.Width = 8; //Avoid clipping
-				if (y == maxSize)
+				if (y == maxSize - 1)
 					source.Height = 8;
 
 				var center = new Vector2(width * 16 / 2, height * 16 / 2);

--- a/Content/Underground/Pottery/TileRecord.cs
+++ b/Content/Underground/Pottery/TileRecord.cs
@@ -1,21 +1,32 @@
 ﻿namespace SpiritReforged.Content.Underground.Pottery;
 
 /// <summary> Records details for tile bestiary purposes. </summary>
-public struct TileRecord(string key, int tileType, params int[] tileStyles)
+public struct TileRecord
 {
 	/// <summary> The default path localization key for <see cref="description"/>. </summary>
 	public const string DescKey = "Mods.SpiritReforged.Tiles.Records";
 
 	/// <summary> The value used for internal reference. For the front-facing name, see <see cref="name"/>. </summary>
-	public string key = key;
+	public readonly string key;
+	public readonly int type;
+	public readonly int[] styles;
 
-	public int type = tileType;
-	public int[] styles = tileStyles;
+	public string name;
+	public string description = Language.GetTextValue(DescKey + ".Common");
 
 	public bool hidden = false;
 	public byte rating = 1;
-	public string name = Language.GetTextValue($"Mods.SpiritReforged.Items.{key}Item.DisplayName");
-	public string description = Language.GetTextValue(DescKey + ".Common");
+
+	public TileRecord(string nameKey, int tileType, params int[] tileStyles)
+	{
+		key = nameKey;
+		type = tileType;
+		styles = tileStyles;
+
+		string modName = TileLoader.GetTile(tileType).Mod.Name;
+		name = Language.GetTextValue($"Mods.{modName}.Items.{key}Item.DisplayName");
+		description = Language.GetTextValue(DescKey + ".Common");
+	}
 
 	/// <summary> Hides this record until discovered. </summary>
 	public TileRecord Hide()
@@ -44,7 +55,7 @@ public struct TileRecord(string key, int tileType, params int[] tileStyles)
 
 	public readonly void DrawIcon(SpriteBatch spriteBatch, Vector2 position, Color color)
 	{
-		const int tileFrame = 18;
+		const int maxSize = 4;
 
 		int tileStyle = styles[0];
 		var data = TileObjectData.GetTileData(type, 0);
@@ -59,26 +70,45 @@ public struct TileRecord(string key, int tileType, params int[] tileStyles)
 		int height = data.Height;
 
 		if (wrapLimit == 0)
-			wrapLimit = data.RandomStyleRange;
+			wrapLimit = (data.RandomStyleRange == 0) ? 2000 : data.RandomStyleRange;
 
 		for (int x = 0; x < width; x++)
 		{
 			for (int y = 0; y < height; y++)
 			{
-				//Expects a horizontal style
-				int startX = (tileStyle % wrapLimit * width + x) * tileFrame;
-				int startY = (tileStyle / wrapLimit * height + y) * tileFrame;
-
-				var source = new Rectangle(startX, startY, 16, 16);
+				var start = FrameStart(x, y);
+				var source = new Rectangle(start.X, start.Y, 16, 16);
 				source.Y += Main.tileFrame[type] * data.CoordinateFullHeight; //Animation
 
-				if (y == 4)
-					source.Height = 8; //Avoid clipping
+				if (x == maxSize)
+					source.Width = 8; //Avoid clipping
+				if (y == maxSize)
+					source.Height = 8;
 
 				var center = new Vector2(width * 16 / 2, height * 16 / 2);
 				var drawPos = position + new Vector2(x * 16, y * 16) - center;
 
 				spriteBatch.Draw(texture, drawPos, source, color, 0, Vector2.Zero, 1, default, 0);
+			}
+		}
+
+		Point FrameStart(int x, int y)
+		{
+			const int tileFrame = 18;
+
+			if (data.StyleHorizontal)
+			{
+				int startX = (tileStyle % wrapLimit * width + x) * tileFrame;
+				int startY = (tileStyle / wrapLimit * height + y) * tileFrame;
+
+				return new Point(startX, startY);
+			}
+			else
+			{
+				int startX = (tileStyle / wrapLimit * width + x) * tileFrame;
+				int startY = (tileStyle % wrapLimit * height + y) * tileFrame;
+
+				return new Point(startX, startY);
 			}
 		}
 	}

--- a/Content/Underground/Tiles/AetherShipment.cs
+++ b/Content/Underground/Tiles/AetherShipment.cs
@@ -198,9 +198,8 @@ public class AetherShipment : PotTile, ISwayTile, ILootTile, ICutAttempt
 		}
 	}
 
-	public LootTable AddLoot(int objectStyle)
+	public void AddLoot(int objectStyle, ILoot loot)
 	{
-		var loot = new LootTable();
 		loot.AddOneFromOptions(1, ItemID.AegisCrystal, ItemID.ArcaneCrystal, ItemID.AegisFruit, ItemID.Ambrosia, ItemID.GummyWorm, ItemID.GalaxyPearl);
 
 		if (Main.expertMode || Main.masterMode)
@@ -209,7 +208,5 @@ public class AetherShipment : PotTile, ISwayTile, ILootTile, ICutAttempt
 			loot.AddCommon(ItemID.ShimmerTorch, 1, 4, 14);
 
 		loot.AddCommon(ItemID.ShimmerArrow, 1, 10, 20);
-
-		return loot;
 	}
 }

--- a/Content/Underground/Tiles/BiomePots.cs
+++ b/Content/Underground/Tiles/BiomePots.cs
@@ -212,10 +212,7 @@ public class BiomePots : PotTile, ILootTile
 		{
 			#region loot
 			var p = Main.player[Player.FindClosest(center, 0, 0)];
-			var loot = new LootTable();
-
-			AddLoot(TileObjectData.GetTileStyle(Main.tile[i, j]), loot);
-			loot.Resolve(new Rectangle((int)center.X - 16, (int)center.Y - 16, 32, 32), p);
+			LootTable.Resolve(i, j, Type, frameX, frameY);
 
 			ItemMethods.SplitCoins((int)(CalculateCoinValue() * GetValue(style)), delegate (int type, int stack)
 			{

--- a/Content/Underground/Tiles/BiomePots.cs
+++ b/Content/Underground/Tiles/BiomePots.cs
@@ -212,7 +212,10 @@ public class BiomePots : PotTile, ILootTile
 		{
 			#region loot
 			var p = Main.player[Player.FindClosest(center, 0, 0)];
-			AddLoot(TileObjectData.GetTileStyle(Main.tile[i, j])).Resolve(new Rectangle((int)center.X - 16, (int)center.Y - 16, 32, 32), p);
+			var loot = new LootTable();
+
+			AddLoot(TileObjectData.GetTileStyle(Main.tile[i, j]), loot);
+			loot.Resolve(new Rectangle((int)center.X - 16, (int)center.Y - 16, 32, 32), p);
 
 			ItemMethods.SplitCoins((int)(CalculateCoinValue() * GetValue(style)), delegate (int type, int stack)
 			{
@@ -359,9 +362,8 @@ public class BiomePots : PotTile, ILootTile
 		Vector2 GetRandom(float distance = 15f) => center + Main.rand.NextVector2Unit() * Main.rand.NextFloat(distance);
 	}
 
-	public LootTable AddLoot(int objectStyle)
+	public void AddLoot(int objectStyle, ILoot loot)
 	{
-		var loot = new LootTable();
 		var style = GetStyle(objectStyle / 3 * 36);
 
 		if (style is Style.Dungeon)
@@ -426,7 +428,6 @@ public class BiomePots : PotTile, ILootTile
 		branch.Add(ItemDropRule.Common(ItemID.HealingPotion, 1, 1, 3));
 
 		loot.Add(new OneFromRulesRule(1, [.. branch]));
-		return loot;
 
 		int ArrowType()
 		{

--- a/Content/Underground/Tiles/CommonPots.cs
+++ b/Content/Underground/Tiles/CommonPots.cs
@@ -1,5 +1,4 @@
 using RubbleAutoloader;
-using SpiritReforged.Common.TileCommon;
 using SpiritReforged.Common.TileCommon.PresetTiles;
 using SpiritReforged.Content.Underground.Pottery;
 using static SpiritReforged.Common.TileCommon.StyleDatabase;
@@ -71,5 +70,5 @@ public class CommonPots : PotTile, ILootTile
 		return true;
 	}
 
-	public LootTable AddLoot(int objectStyle) => ModContent.GetInstance<Pots>().AddLoot(objectStyle);
+	public void AddLoot(int objectStyle, ILoot loot) => ModContent.GetInstance<Pots>().AddLoot(objectStyle, loot);
 }

--- a/Content/Underground/Tiles/LootTable.cs
+++ b/Content/Underground/Tiles/LootTable.cs
@@ -7,7 +7,7 @@ namespace SpiritReforged.Content.Underground.Tiles;
 /// Does not drop items automatically unless used alongside <see cref="PotTile"/>. See <see cref="LootTable.Resolve"/>. </summary>
 public interface ILootTile
 {
-	public LootTable AddLoot(int objectStyle);
+	public void AddLoot(int objectStyle, ILoot loot);
 }
 
 /// <summary> A self-contained loot table. </summary>

--- a/Content/Underground/Tiles/OrnatePots.cs
+++ b/Content/Underground/Tiles/OrnatePots.cs
@@ -63,12 +63,6 @@ public class OrnatePots : PotTile, ILootTile
 			{
 				Item.NewItem(new EntitySource_TileBreak(i, j), spawn, new Item(type, stack), noGrabDelay: true);
 			});
-
-			var p = Main.player[Player.FindClosest(spawn, 0, 0)];
-			var loot = new LootTable();
-
-			AddLoot(TileObjectData.GetTileStyle(Main.tile[i, j]), loot);
-			loot.Resolve(new Rectangle((int)spawn.X - 16, (int)spawn.Y - 16, 32, 32), p);
 		}
 
 		base.KillMultiTile(i, j, frameX, frameY);

--- a/Content/Underground/Tiles/OrnatePots.cs
+++ b/Content/Underground/Tiles/OrnatePots.cs
@@ -65,7 +65,10 @@ public class OrnatePots : PotTile, ILootTile
 			});
 
 			var p = Main.player[Player.FindClosest(spawn, 0, 0)];
-			AddLoot(TileObjectData.GetTileStyle(Main.tile[i, j])).Resolve(new Rectangle((int)spawn.X - 16, (int)spawn.Y - 16, 32, 32), p);
+			var loot = new LootTable();
+
+			AddLoot(TileObjectData.GetTileStyle(Main.tile[i, j]), loot);
+			loot.Resolve(new Rectangle((int)spawn.X - 16, (int)spawn.Y - 16, 32, 32), p);
 		}
 
 		base.KillMultiTile(i, j, frameX, frameY);
@@ -83,13 +86,10 @@ public class OrnatePots : PotTile, ILootTile
 		}
 	}
 
-	public LootTable AddLoot(int objectStyle)
+	public void AddLoot(int objectStyle, ILoot loot)
 	{
-		var loot = new LootTable();
 		loot.Add(ItemDropRule.Common(ItemID.LuckPotion, 2, 1, 2));
 		loot.Add(ItemDropRule.Common(ItemID.HealingPotion, 1, 1, 3));
-
-		return loot;
 	}
 
 	public override bool PreDraw(int i, int j, SpriteBatch spriteBatch)

--- a/Content/Underground/Tiles/Pots.cs
+++ b/Content/Underground/Tiles/Pots.cs
@@ -108,10 +108,9 @@ public class Pots : PotTile, ILootTile
 		TileObjectData.addTile(Type);
 	}
 
-	public LootTable AddLoot(int objectStyle)
+	public void AddLoot(int objectStyle, ILoot loot)
 	{
 		string styleName = StyleDatabase.GetName(Type, (byte)objectStyle);
-		var loot = new LootTable();
 
 		List<IItemDropRule> branch = []; //Full branch to select ONE option from
 
@@ -150,7 +149,6 @@ public class Pots : PotTile, ILootTile
 			branch.Add(ItemDropRule.Common(ItemID.Rope, 1, 20, 40));
 
 		loot.Add(new OneFromRulesRule(1, [.. branch]));
-		return loot;
 
 		int TorchType()
 		{

--- a/Content/Underground/Tiles/ScryingPot.cs
+++ b/Content/Underground/Tiles/ScryingPot.cs
@@ -72,7 +72,10 @@ public class ScryingPot : PotTile, ILootTile
 			});
 
 			var p = Main.player[Player.FindClosest(spawn, 0, 0)];
-			AddLoot(TileObjectData.GetTileStyle(Main.tile[i, j])).Resolve(new Rectangle((int)spawn.X - 16, (int)spawn.Y - 16, 32, 32), p);
+			var loot = new LootTable();
+
+			AddLoot(TileObjectData.GetTileStyle(Main.tile[i, j]), loot);
+			loot.Resolve(new Rectangle((int)spawn.X - 16, (int)spawn.Y - 16, 32, 32), p);
 		}
 
 		if (!Main.dedServ)
@@ -100,11 +103,9 @@ public class ScryingPot : PotTile, ILootTile
 		}
 	}
 
-	public LootTable AddLoot(int objectStyle)
+	public void AddLoot(int objectStyle, ILoot loot)
 	{
-		var loot = new LootTable();
 		loot.AddOneFromOptions(1, ItemID.NightOwlPotion, ItemID.ShinePotion, ItemID.BiomeSightPotion, ItemID.TrapsightPotion, ItemID.HunterPotion, ItemID.SpelunkerPotion);
-		return loot;
 	}
 
 	public override bool PreDraw(int i, int j, SpriteBatch spriteBatch)

--- a/Content/Underground/Tiles/ScryingPot.cs
+++ b/Content/Underground/Tiles/ScryingPot.cs
@@ -71,11 +71,7 @@ public class ScryingPot : PotTile, ILootTile
 				Item.NewItem(new EntitySource_TileBreak(i, j), spawn, new Item(type, stack), noGrabDelay: true);
 			});
 
-			var p = Main.player[Player.FindClosest(spawn, 0, 0)];
-			var loot = new LootTable();
-
-			AddLoot(TileObjectData.GetTileStyle(Main.tile[i, j]), loot);
-			loot.Resolve(new Rectangle((int)spawn.X - 16, (int)spawn.Y - 16, 32, 32), p);
+			LootTable.Resolve(i, j, Type, frameX, frameY);
 		}
 
 		if (!Main.dedServ)

--- a/Content/Underground/Tiles/SilverPlatters.cs
+++ b/Content/Underground/Tiles/SilverPlatters.cs
@@ -70,15 +70,8 @@ public class SilverPlatters : PotTile, ILootTile
 
 		if (Main.netMode != NetmodeID.MultiplayerClient)
 		{
-			var p = Main.player[Player.FindClosest(center, 0, 0)];
-
 			for (int x = 0; x < 2; x++) //Roll twice
-			{
-				var loot = new LootTable();
-
-				AddLoot(TileObjectData.GetTileStyle(t), loot);
-				loot.Resolve(new Rectangle((int)center.X - 16, (int)center.Y - 16, 32, 32), p);
-			}
+				LootTable.Resolve(i, j, Type, frameX, frameY);
 		}
 
 		if (!Main.dedServ)

--- a/Content/Underground/Tiles/SilverPlatters.cs
+++ b/Content/Underground/Tiles/SilverPlatters.cs
@@ -71,9 +71,14 @@ public class SilverPlatters : PotTile, ILootTile
 		if (Main.netMode != NetmodeID.MultiplayerClient)
 		{
 			var p = Main.player[Player.FindClosest(center, 0, 0)];
-			
+
 			for (int x = 0; x < 2; x++) //Roll twice
-				AddLoot(TileObjectData.GetTileStyle(t)).Resolve(new Rectangle((int)center.X - 16, (int)center.Y - 16, 32, 32), p);
+			{
+				var loot = new LootTable();
+
+				AddLoot(TileObjectData.GetTileStyle(t), loot);
+				loot.Resolve(new Rectangle((int)center.X - 16, (int)center.Y - 16, 32, 32), p);
+			}
 		}
 
 		if (!Main.dedServ)
@@ -94,10 +99,8 @@ public class SilverPlatters : PotTile, ILootTile
 		}
 	}
 
-	public LootTable AddLoot(int objectStyle)
+	public void AddLoot(int objectStyle, ILoot loot)
 	{
-		var loot = new LootTable();
-
 		loot.AddOneFromOptions(1, ItemID.RoastedBird, ItemID.BunnyStew, ItemID.CookedFish, ItemID.GrilledSquirrel, ItemID.SauteedFrogLegs,
 			ModContent.ItemType<CookedMeat>(), ModContent.ItemType<FishChips>(), ModContent.ItemType<HoneySalmon>());
 
@@ -106,6 +109,5 @@ public class SilverPlatters : PotTile, ILootTile
 			ItemID.RoastedDuck, ItemID.ChickenNugget, ItemID.SeafoodDinner, ItemID.GrubSoup, ItemID.ShrimpPoBoy, ItemID.Pho, ItemID.FroggleBunwich));
 
 		loot.Add(rule);
-		return loot;
 	}
 }

--- a/Content/Underground/Tiles/StuffedPots.cs
+++ b/Content/Underground/Tiles/StuffedPots.cs
@@ -96,12 +96,9 @@ public class StuffedPots : PotTile, ILootTile
 		}
 	}
 
-	public LootTable AddLoot(int objectStyle)
+	public void AddLoot(int objectStyle, ILoot loot)
 	{
-		var loot = new LootTable();
 		loot.Add(ItemDropRule.Common(ItemID.Glowstick, 1, 10, 25));
 		loot.Add(ItemDropRule.Common(ItemID.StrangeBrew, 1, 2, 8));
-
-		return loot;
 	}
 }

--- a/Content/Underground/Tiles/WormPot.cs
+++ b/Content/Underground/Tiles/WormPot.cs
@@ -134,16 +134,12 @@ public class WormPot : PotTile, ISwayTile, ILootTile, ICutAttempt
 				npc.velocity = (Vector2.UnitY * -Main.rand.NextFloat(.5f, 2f)).RotatedByRandom(2f);
 			}
 
-			var p = Main.player[Player.FindClosest(position, 0, 0)];
-			var loot = new LootTable();
-
-			AddLoot(TileObjectData.GetTileStyle(Main.tile[i, j]), loot);
-			loot.Resolve(new Rectangle((int)position.X - 16, (int)position.Y - 16, 32, 32), p);
-
 			ItemMethods.SplitCoins(Main.rand.Next(30000, 50000), delegate (int type, int stack)
 			{
 				Item.NewItem(new EntitySource_TileBreak(i, j), position, new Item(type, stack), noGrabDelay: true);
 			});
+
+			LootTable.Resolve(i, j, Type, frameX, frameY);
 		}
 
 		if (!Main.dedServ)

--- a/Content/Underground/Tiles/WormPot.cs
+++ b/Content/Underground/Tiles/WormPot.cs
@@ -135,7 +135,10 @@ public class WormPot : PotTile, ISwayTile, ILootTile, ICutAttempt
 			}
 
 			var p = Main.player[Player.FindClosest(position, 0, 0)];
-			AddLoot(TileObjectData.GetTileStyle(Main.tile[i, j])).Resolve(new Rectangle((int)position.X - 16, (int)position.Y - 16, 32, 32), p);
+			var loot = new LootTable();
+
+			AddLoot(TileObjectData.GetTileStyle(Main.tile[i, j]), loot);
+			loot.Resolve(new Rectangle((int)position.X - 16, (int)position.Y - 16, 32, 32), p);
 
 			ItemMethods.SplitCoins(Main.rand.Next(30000, 50000), delegate (int type, int stack)
 			{
@@ -177,13 +180,9 @@ public class WormPot : PotTile, ISwayTile, ILootTile, ICutAttempt
 			source, color, rotation, origin, 1, SpriteEffects.None, 0);
 	}
 
-	public LootTable AddLoot(int objectStyle)
+	public void AddLoot(int objectStyle, ILoot loot)
 	{
-		var loot = new LootTable();
-
 		loot.Add(ItemDropRule.NotScalingWithLuckWithNumerator(ItemID.WhoopieCushion, 100, 15));
 		loot.AddCommon(ItemID.CanOfWorms, 1, 1, 2);
-
-		return loot;
 	}
 }

--- a/Content/Underground/Tiles/ZenithPots.cs
+++ b/Content/Underground/Tiles/ZenithPots.cs
@@ -34,5 +34,5 @@ public class ZenithPots : PotTile, ILootTile
 		DustType = Autoloader.IsRubble(Type) ? -1 : DustID.TreasureSparkle;
 	}
 
-	public LootTable AddLoot(int objectStyle) => ModContent.GetInstance<Pots>().AddLoot(objectStyle);
+	public void AddLoot(int objectStyle, ILoot loot) => ModContent.GetInstance<Pots>().AddLoot(objectStyle, loot);
 }

--- a/SpiritReforged.Call.cs
+++ b/SpiritReforged.Call.cs
@@ -1,6 +1,7 @@
 ﻿using SpiritReforged.Common.ItemCommon.Backpacks;
 using SpiritReforged.Content.Forest.Safekeeper;
 using SpiritReforged.Content.Savanna.Ecotone;
+using SpiritReforged.Content.Underground.Pottery;
 using SpiritReforged.Content.Underground.Tiles.Potion;
 
 namespace SpiritReforged;
@@ -53,6 +54,10 @@ public partial class SpiritReforgedMod : Mod
 							throw new ArgumentException("HasBackpack parameters should be 2 elements long: (\"HasBackpack\", player)!");
 
 						return player.GetModPlayer<BackpackPlayer>().backpack.ModItem is BackpackItem;
+					}
+				case "AddPotstiaryRecord":
+					{
+						return RecordHandler.ManualAddRecord(args[1..]);
 					}
 				default:
 					{

--- a/SpiritReforged.Call.cs
+++ b/SpiritReforged.Call.cs
@@ -59,6 +59,19 @@ public partial class SpiritReforgedMod : Mod
 					{
 						return RecordHandler.ManualAddRecord(args[1..]);
 					}
+				case "PotDiscovered":
+					{
+						if (args.Length > 3)
+							throw new ArgumentException("PotDiscovered parameters should be 3 elements long: (\"PotDiscovered\", string, player)");
+
+						if (args[1] is not string key)
+							throw new ArgumentException("PotDiscovered parameter 1 should be a string.");
+
+						if (args[2] is not Player player)
+							throw new ArgumentException("PotDiscovered parameter 2 should be a Player.");
+
+						return player.GetModPlayer<RecordPlayer>().IsValidated(key);
+					}
 				default:
 					{
 						Logger.Error($"Call Error: Context '{context}' is invalid.");


### PR DESCRIPTION
Adds the ability for modders to easily register pots in the Potstiary, with automatic unlock and save handling, but not placeable item and recipe handling.

`"AddPotstiaryRecord"` call registers a pot in the Potstiary (expects a minimum of 3 additional arguments and a maximum of 8).

`"PotDiscovered"` call checks whether the entry corresponding to the given key was unlocked by the given player (expects exactly 2 additional arguments).