### PR TITLE
Potstiary entry change

### DIFF
--- a/Common/UI/PotCatalogue/CatalogueUI.cs
+++ b/Common/UI/PotCatalogue/CatalogueUI.cs
@@ -57,7 +57,7 @@ public partial class CatalogueUI : AutoUIState
 			bool locked = !Main.LocalPlayer.GetModPlayer<RecordPlayer>().IsValidated(value.key);
 			bool newAndShiny = Main.LocalPlayer.GetModPlayer<RecordPlayer>().IsNew(value.key);
 
-			if (!value.hidden || !locked)
+			if (value.hidden?.Invoke() != true || !locked)
 				_entries.AddEntry(new CatalogueEntry(value, locked, newAndShiny));
 		}
 	}

--- a/Content/Underground/Pottery/TileRecord.cs
+++ b/Content/Underground/Pottery/TileRecord.cs
@@ -12,7 +12,7 @@ public struct TileRecord(string key, int tileType, params int[] tileStyles)
 	public int type = tileType;
 	public int[] styles = tileStyles;
 
-	public bool hidden = false;
+	public Func<bool> hidden;
 	public byte rating = 1;
 	public string name = Language.GetTextValue($"Mods.SpiritReforged.Items.{key}Item.DisplayName");
 	public string description = Language.GetTextValue(DescKey + ".Common");
@@ -20,7 +20,14 @@ public struct TileRecord(string key, int tileType, params int[] tileStyles)
 	/// <summary> Hides this record until discovered. </summary>
 	public TileRecord Hide()
 	{
-		hidden = true;
+		hidden = () => true;
+		return this;
+	}
+
+	/// <inheritdoc cref="Hide()"/>
+	public TileRecord Hide(Func<bool> condition)
+	{
+		hidden = condition;
 		return this;
 	}
 

--- a/Content/Underground/Tiles/BiomePots.cs
+++ b/Content/Underground/Tiles/BiomePots.cs
@@ -40,8 +40,18 @@ public class BiomePots : PotTile, ILootTile
 
 	public override void AddRecord(int type, StyleDatabase.StyleGroup group)
 	{
-		var record = new TileRecord(group.name, type, group.styles);
-		RecordHandler.Records.Add(record.AddRating(2).AddDescription(Language.GetText(TileRecord.DescKey + ".Biome")));
+		var record = new TileRecord(group.name, type, group.styles).AddRating(2).AddDescription(Language.GetText(TileRecord.DescKey + ".Biome"));
+
+		if (group.name == "BiomePotsCrimson")
+		{
+			record.Hide(() => !WorldGen.crimson); //Conditionally hide some entries
+		}
+		else if (group.name == "BiomePotsCorruption")
+		{
+			record.Hide(() => WorldGen.crimson);
+		}
+
+		RecordHandler.Records.Add(record);
 	}
 
 	public override Dictionary<string, int[]> TileStyles => new()

--- a/Content/Underground/Tiles/Pots.cs
+++ b/Content/Underground/Tiles/Pots.cs
@@ -35,6 +35,22 @@ public class Pots : PotTile, ILootTile
 		}
 	}
 
+	public override void AddRecord(int type, StyleDatabase.StyleGroup group)
+	{
+		if (group.name == "PotsCrimson")
+		{
+			RecordHandler.Records.Add(new TileRecord(group.name, type, group.styles).Hide(() => !WorldGen.crimson)); //Conditionally hide some entries
+		}
+		else if (group.name == "PotsCorruption")
+		{
+			RecordHandler.Records.Add(new TileRecord(group.name, type, group.styles).Hide(() => WorldGen.crimson));
+		}
+		else
+		{
+			base.AddRecord(type, group);
+		}
+	}
+
 	public override void AddItemRecipes(ModItem modItem, StyleDatabase.StyleGroup group)
 	{
 		int wheel = ModContent.TileType<PotteryWheel>();


### PR DESCRIPTION
Changes `TileRecord.hidden` from `bool` to `Func<bool>`. Hides Corruption/Crimson pot entries from the Potstiary on the opposite world evil unless unlocked.