### PR TITLE
add a ton of checks for remnants

### DIFF
--- a/Common/ModCompat/CrossMod.cs
+++ b/Common/ModCompat/CrossMod.cs
@@ -45,6 +45,7 @@ internal static class CrossMod
 		public static explicit operator Mod(ModEntry e) => e.Instance;
 	}
 
+	public static readonly ModEntry Remnants = new("Remnants");
 	public static readonly ModEntry Redemption = new("Redemption");
 	public static readonly ModEntry Fables = new("CalamityFables");
 	public static readonly ModEntry Thorium = new("ThoriumMod");

--- a/Common/WorldGeneration/Micropasses/Passes/ButterflyMicropass.cs
+++ b/Common/WorldGeneration/Micropasses/Passes/ButterflyMicropass.cs
@@ -8,6 +8,7 @@ internal class ButterflyMicropass : Micropass
 {
 	public override string WorldGenName => "Butterfly Shrines";
 
+	// Remnants will take care of our butterfly shrines on their end at some point, change in the future
 	public override int GetWorldGenIndexInsert(List<GenPass> passes, ref bool afterIndex) => passes.FindIndex(genpass => genpass.Name.Equals("Sunflowers"));
 
 	public override void Run(GenerationProgress progress, Terraria.IO.GameConfiguration config)
@@ -15,7 +16,7 @@ internal class ButterflyMicropass : Micropass
 		const int maxTries = 2000;
 
 		progress.Message = Language.GetTextValue("Mods.SpiritReforged.Generation.Butterfly");
-		int repeats = Main.maxTilesX / WorldGen.WorldSizeSmallX; //1 shrine in small and medium worlds, 2 in large
+		int repeats = Main.maxTilesX / WorldGen.WorldSizeSmallX; // 1 shrine in small and medium worlds, 2 in large
 
 		for (int i = 0; i < repeats; i++)
 		{

--- a/Common/WorldGeneration/Micropasses/Passes/PotteryStructureMicropass.cs
+++ b/Common/WorldGeneration/Micropasses/Passes/PotteryStructureMicropass.cs
@@ -1,4 +1,5 @@
-﻿using SpiritReforged.Content.Underground.Pottery;
+﻿using SpiritReforged.Common.ModCompat;
+using SpiritReforged.Content.Underground.Pottery;
 using SpiritReforged.Content.Underground.Tiles;
 using SpiritReforged.Content.Underground.Tiles.Potion;
 using System.Linq;
@@ -19,7 +20,6 @@ internal class PotteryStructureMicropass : Micropass
 
 	public override void Run(GenerationProgress progress, Terraria.IO.GameConfiguration config)
 	{
-		const int xPadding = 40;
 		const int maxTries = 1000; //Failsafe
 
 		progress.Message = Language.GetTextValue("Mods.SpiritReforged.Generation.Pottery");
@@ -27,11 +27,12 @@ internal class PotteryStructureMicropass : Micropass
 		HashSet<Rectangle> regions = [];
 		int maxStructures = Main.maxTilesX / WorldGen.WorldSizeSmallX * 5;
 		int structures = 0;
+		int xPadding = CrossMod.Remnants.Enabled ? 400 : 40;
 
 		for (int t = 0; t < maxTries; t++)
 		{
 			int x = WorldGen.genRand.Next(xPadding, Main.maxTilesX - xPadding);
-			int y = WorldGen.genRand.Next((int)Main.worldSurface, Main.UnderworldLayer - 20);
+			int y = WorldGen.genRand.Next((int)Main.worldSurface + 50, Main.UnderworldLayer - 20);
 
 			WorldMethods.FindGround(x, ref y);
 

--- a/Common/WorldGeneration/QuickConversion.cs
+++ b/Common/WorldGeneration/QuickConversion.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using SpiritReforged.Common.ModCompat;
+using System.Linq;
 using Terraria.DataStructures;
 
 namespace SpiritReforged.Common.WorldGeneration;
@@ -19,6 +20,9 @@ internal class QuickConversion
 		Dictionary<BiomeType, int> biomeCounts = new() { { BiomeType.Purity, 0 }, { BiomeType.Jungle, 0 }, { BiomeType.Ice, 0 }, { BiomeType.Mushroom, 0 }, 
 			{ BiomeType.Desert, 0 } };
 
+		// Remnants jungles are much more rocky and muddy, making it harder to detect with our normal values
+		int jungleStep = CrossMod.Remnants.Enabled ? 2 : 1;
+
 		for (int i = position.X; i < position.X + size.X; i++)
 		{
 			for (int j = position.Y; j < position.Y + size.Y; j++)
@@ -29,7 +33,7 @@ internal class QuickConversion
 					continue;
 
 				if (tile.TileType is TileID.JungleGrass or TileID.JungleVines or TileID.JunglePlants)
-					biomeCounts[BiomeType.Jungle]++;
+					biomeCounts[BiomeType.Jungle] += jungleStep;
 				else if (tile.TileType is TileID.Dirt or TileID.Stone or TileID.ClayBlock)
 					biomeCounts[BiomeType.Purity]++;
 				else if (tile.TileType is TileID.SnowBlock or TileID.IceBlock)

--- a/Content/Savanna/Ecotone/SavannaEcotone.cs
+++ b/Content/Savanna/Ecotone/SavannaEcotone.cs
@@ -1,4 +1,5 @@
-﻿using SpiritReforged.Common.TileCommon.Tree;
+﻿using SpiritReforged.Common.ModCompat;
+using SpiritReforged.Common.TileCommon.Tree;
 using SpiritReforged.Common.WallCommon;
 using SpiritReforged.Common.WorldGeneration;
 using SpiritReforged.Common.WorldGeneration.Ecotones;
@@ -18,6 +19,8 @@ namespace SpiritReforged.Content.Savanna.Ecotone;
 
 internal class SavannaEcotone : EcotoneBase
 {
+	private delegate bool OnAttempt(int i, int j);
+
 	[WorldBound]
 	public static Rectangle SavannaArea;
 	private static int Steps = 0;
@@ -241,8 +244,9 @@ internal class SavannaEcotone : EcotoneBase
 		if (SavannaArea.IsEmpty)
 			return;
 
-		const int chanceMax = 90; //Maximum odds to generate a tree
 		const int minimumTreeSpace = 7;
+
+		int chanceMax = CrossMod.Remnants.Enabled ? 40 : 90; // Maximum odds to generate a tree - lower in Remnants
 
 		progress.Message = Language.GetTextValue("Mods.SpiritReforged.Generation.SavannaObjects");
 		HashSet<int> treeSpacing = [];
@@ -272,7 +276,9 @@ internal class SavannaEcotone : EcotoneBase
 			static bool HoleGen(int i, int j)
 			{
 				HashSet<int> soft = [TileID.Dirt, TileID.CorruptGrass, TileID.CrimsonGrass, TileID.Sand, ModContent.TileType<SavannaDirt>()];
-				return soft.Contains(Main.tile[i, j].TileType);
+
+				return soft.Contains(Main.tile[i, j].TileType) && Collision.SolidCollision(new Vector2((i - 28) * 16, j * 16), 32, 64)
+					&& Collision.SolidCollision(new Vector2((i + 26) * 16, j * 16), 32, 32);
 			}
 		}
 
@@ -297,23 +303,26 @@ internal class SavannaEcotone : EcotoneBase
 				if (flags == OpenFlags.None)
 					continue;
 
-				if (tile.TileType == TileID.Stone && WorldGen.genRand.NextBool()) //Place stone piles on stone
+				if (tile.HasTile)
 				{
-					if (WorldGen.genRand.NextBool(3))
-						WorldGen.PlaceTile(i, j - 1, ModContent.TileType<SavannaRockLarge>(), true, style: WorldGen.genRand.Next(3));
-					else
-						WorldGen.PlaceTile(i, j - 1, ModContent.TileType<SavannaRockSmall>(), true, style: WorldGen.genRand.Next(3));
-				}
+					if (tile.TileType == TileID.Stone && WorldGen.genRand.NextBool()) //Place stone piles on stone
+					{
+						if (WorldGen.genRand.NextBool(3))
+							WorldGen.PlaceTile(i, j - 1, ModContent.TileType<SavannaRockLarge>(), true, style: WorldGen.genRand.Next(3));
+						else
+							WorldGen.PlaceTile(i, j - 1, ModContent.TileType<SavannaRockSmall>(), true, style: WorldGen.genRand.Next(3));
+					}
 
-				if (tile.TileType == ModContent.TileType<SavannaDirt>())
-				{
-					tile.TileType = (ushort)ModContent.TileType<SavannaGrass>(); //Grow grass on dirt
+					if (tile.TileType == ModContent.TileType<SavannaDirt>())
+					{
+						tile.TileType = (ushort)ModContent.TileType<SavannaGrass>(); //Grow grass on dirt
 
-					if (flags.HasFlag(OpenFlags.Above))
-						grassTop.Add(new Point16(i, j));
+						if (flags.HasFlag(OpenFlags.Above))
+							grassTop.Add(new Point16(i, j));
 
-					if (tile.WallType == ModContent.WallType<SavannaDirtWall>())
-						tile.Clear(TileDataType.Wall); //Clear walls again, but specifically for savanna dirt
+						if (tile.WallType == ModContent.WallType<SavannaDirtWall>())
+							tile.Clear(TileDataType.Wall); //Clear walls again, but specifically for savanna dirt
+					}
 				}
 
 				if (WorldGen.genRand.NextBool(120)) //Rare bones
@@ -324,6 +333,7 @@ internal class SavannaEcotone : EcotoneBase
 			Campsite();
 
 		int treeOdds = chanceMax;
+
 		foreach (var p in grassTop)
 		{
 			(int i, int j) = (p.X, p.Y - 1);
@@ -515,7 +525,6 @@ internal class SavannaEcotone : EcotoneBase
 		return factor;
 	}
 
-	private delegate bool OnAttempt(int i, int j);
 	private static bool IterateGen(int tries, OnAttempt isValid, out int x, out int y, string structureName = default)
 	{
 		for (int t = 0; t < tries; t++)


### PR DESCRIPTION
- Makes Fishing Coves & Pottery structures spawn at least 400 tiles away from the edges of the world with Remnants on, avoiding some poor overlapping biomes
- Moves Pottery structures down, which would poke out to the surface even on some vanilla small/medium worlds
- Stops Fishing Coves from placing over Granite and Marble
- Made the Savanna's Watering Holes spawn only if there's walls to hold in their water at the top
- Made Savanna population gen properly check `tile.HasTile`, stopping a TON (from 78,000 iterations to ~350) of useless checks, fixing Remnants population
- Made our automatic biome conversion more sensitive to jungles with Remnants
- Made Acacia trees spawn much more often with Remnants on

All of these changes are either for functionality or per wombat's (of Remnants) request.