### PR TITLE
Misc fixes

### DIFF
--- a/Common/ProjectileCommon/Abstract/BaseClubCommon.cs
+++ b/Common/ProjectileCommon/Abstract/BaseClubCommon.cs
@@ -10,6 +10,12 @@ namespace SpiritReforged.Common.ProjectileCommon.Abstract;
 
 public abstract partial class BaseClubProj : ModProjectile
 {
+	public static readonly SoundStyle DefaultReady = new("SpiritReforged/Assets/SFX/Item/ClubReady")
+	{
+		Volume = 0.5f,
+		PitchVariance = 0.15f
+	};
+
 	public static readonly SoundStyle DefaultSwing = new("SpiritReforged/Assets/SFX/Item/GenericClubWhoosh")
 	{
 		Volume = 0.66f

--- a/Common/ProjectileCommon/Abstract/BaseClubProj.cs
+++ b/Common/ProjectileCommon/Abstract/BaseClubProj.cs
@@ -14,11 +14,6 @@ public abstract partial class BaseClubProj(Vector2 textureSize) : ModProjectile
 	public record struct ClubParameters(bool HasIndicator = true, Color ChargeColor = default);
 	internal const int MAX_FLICKERTIME = 20;
 
-	public static readonly SoundStyle Ready = new("SpiritReforged/Assets/SFX/Item/ClubReady")
-	{
-		PitchVariance = 0.15f
-	};
-
 	internal readonly Vector2 Size = textureSize;
 
 	public float DamageScaling { get; private set; }

--- a/Common/ProjectileCommon/Abstract/BaseClubVirtual.cs
+++ b/Common/ProjectileCommon/Abstract/BaseClubVirtual.cs
@@ -80,7 +80,7 @@ public abstract partial class BaseClubProj : ModProjectile
 
 			if (!Main.dedServ && _parameters.HasIndicator)
 			{
-				SoundEngine.PlaySound(Ready, Projectile.Center);
+				SoundEngine.PlaySound(DefaultReady, Projectile.Center);
 				_flickerTime = MAX_FLICKERTIME;
 			}
 

--- a/Content/Forest/MagicPowder/Flarepowder.cs
+++ b/Content/Forest/MagicPowder/Flarepowder.cs
@@ -83,7 +83,7 @@ public class Flarepowder : ModItem
 		Item.consumable = true;
 		Item.noMelee = true;
 		Item.shoot = ModContent.ProjectileType<FlarepowderDust>();
-		Item.shootSpeed = 5;
+		Item.shootSpeed = 5.7f;
 		Item.value = Item.sellPrice(copper: 4);
 	}
 

--- a/Content/Forest/MagicPowder/Flarepowder.cs
+++ b/Content/Forest/MagicPowder/Flarepowder.cs
@@ -7,7 +7,6 @@ using SpiritReforged.Common.ProjectileCommon;
 using SpiritReforged.Common.Visuals;
 using SpiritReforged.Content.Particles;
 using System.IO;
-using Terraria;
 using Terraria.Audio;
 using Terraria.DataStructures;
 
@@ -117,6 +116,16 @@ internal class FlarepowderDust : ModProjectile, IManualTrailProjectile
 	public virtual Color[] Colors => [Color.LightCoral, Color.Orange, Color.Goldenrod];
 	public override string Texture => DrawHelpers.RequestLocal(GetType(), nameof(FlarepowderDust));
 
+	public static readonly SoundStyle Impact = new("SpiritReforged/Assets/SFX/Projectile/Impact_Hard")
+	{
+		PitchRange = (0f, 0.75f),
+		Volume = 0.5f,
+		MaxInstances = 5
+	};
+
+	/// <summary> Represents a min to max value range. </summary>
+	public (float, float) randomTimeLeft;
+
 	public void DoTrailCreation(TrailManager tm)
 	{
 		float scale = Projectile.scale;
@@ -135,6 +144,7 @@ internal class FlarepowderDust : ModProjectile, IManualTrailProjectile
 		Projectile.tileCollide = false;
 		Projectile.ignoreWater = true;
 		Projectile.timeLeft = TimeLeftMax;
+		randomTimeLeft = (0.6f, 1f);
 	}
 
 	public override void AI()
@@ -159,7 +169,7 @@ internal class FlarepowderDust : ModProjectile, IManualTrailProjectile
 				const float range = 0.01f;
 
 				Projectile.ai[0] = Main.rand.NextFloat(-range, range);
-				Projectile.timeLeft = (int)(Projectile.timeLeft * Main.rand.NextFloat(0.6f, 1f));
+				Projectile.timeLeft = (int)(Projectile.timeLeft * Main.rand.NextFloat(randomTimeLeft.Item1, randomTimeLeft.Item2));
 
 				Projectile.netUpdate = true;
 			}
@@ -195,8 +205,13 @@ internal class FlarepowderDust : ModProjectile, IManualTrailProjectile
 		Projectile.Resize(explosion, explosion);
 		Projectile.Damage();
 
-		SoundEngine.PlaySound(SoundID.DD2_LightningBugZap with { PitchRange = (0.5f, 1f), Volume = .35f, MaxInstances = 5 }, Projectile.Center);
-		SoundEngine.PlaySound(new SoundStyle("SpiritReforged/Assets/SFX/Projectile/Impact_Hard") with { PitchRange = (0f, 0.75f), Volume = .5f, MaxInstances = 5 }, Projectile.Center);
+		PlayDeathSound();
+	}
+
+	public virtual void PlayDeathSound()
+	{
+		SoundEngine.PlaySound(SoundID.DD2_LightningBugZap with { PitchRange = (0.5f, 1f), Volume = 0.35f, MaxInstances = 5 }, Projectile.Center);
+		SoundEngine.PlaySound(Impact, Projectile.Center);
 	}
 
 	public override bool PreDraw(ref Color lightColor)

--- a/Content/Forest/MagicPowder/Flarepowder.cs
+++ b/Content/Forest/MagicPowder/Flarepowder.cs
@@ -113,7 +113,7 @@ internal class FlarepowderDust : ModProjectile, IManualTrailProjectile
 	public const int TimeLeftMax = 60 * 3;
 
 	/// <summary> Must have 3 elements. </summary>
-	public virtual Color[] Colors => [Color.LightCoral, Color.Orange, Color.Goldenrod];
+	public virtual Color[] Colors => [new Color(216, 67, 40), Color.OrangeRed, Color.Goldenrod];
 	public override string Texture => DrawHelpers.RequestLocal(GetType(), nameof(FlarepowderDust));
 
 	public static readonly SoundStyle Impact = new("SpiritReforged/Assets/SFX/Projectile/Impact_Hard")
@@ -144,38 +144,13 @@ internal class FlarepowderDust : ModProjectile, IManualTrailProjectile
 		Projectile.tileCollide = false;
 		Projectile.ignoreWater = true;
 		Projectile.timeLeft = TimeLeftMax;
-		randomTimeLeft = (0.6f, 1f);
+		randomTimeLeft = (0.35f, 0.6f);
 	}
 
 	public override void AI()
 	{
-		if (Projectile.timeLeft == TimeLeftMax) //On spawn
-		{
-			Projectile.frame = Main.rand.Next(Main.projFrames[Type]);
-			Projectile.scale = Main.rand.NextFloat(0.5f, 1f);
-
-			for (int i = 0; i < 2; i++)
-			{
-				float mag = Main.rand.NextFloat();
-				var velocity = (Projectile.velocity * mag).RotatedByRandom(0.2f);
-				var color = Color.Lerp(Colors[0], Colors[1], mag) * 3;
-
-				ParticleHandler.SpawnParticle(new MagicParticle(Projectile.Center, velocity * 0.75f, Colors[0], Main.rand.NextFloat(0.1f, 1f), Main.rand.Next(20, 200)));
-				ParticleHandler.SpawnParticle(new SmokeCloud(Projectile.Center + Vector2.Normalize(Projectile.velocity) * 10, velocity, color, Main.rand.NextFloat(0.05f, 0.1f), Common.Easing.EaseBuilder.EaseCircularInOut, Main.rand.Next(20, 60)));
-			}
-
-			if (Projectile.owner == Main.myPlayer)
-			{
-				const float range = 0.01f;
-
-				Projectile.ai[0] = Main.rand.NextFloat(-range, range);
-				Projectile.timeLeft = (int)(Projectile.timeLeft * Main.rand.NextFloat(randomTimeLeft.Item1, randomTimeLeft.Item2));
-
-				Projectile.netUpdate = true;
-			}
-
-			TrailManager.ManualTrailSpawn(Projectile);
-		}
+		if (Projectile.timeLeft == TimeLeftMax)
+			OnClientSpawn(true);
 
 		if (Projectile.velocity.Length() > 1.25f && Main.rand.NextBool(5))
 			SpawnDust(Projectile.Center + Main.rand.NextVector2Unit() * Main.rand.NextFloat(20f));
@@ -185,6 +160,37 @@ internal class FlarepowderDust : ModProjectile, IManualTrailProjectile
 		Projectile.rotation += Projectile.ai[0];
 
 		Projectile.UpdateFrame(10);
+	}
+
+	public virtual void OnClientSpawn(bool doDustSpawn)
+	{
+		Projectile.frame = Main.rand.Next(Main.projFrames[Type]);
+		Projectile.scale = Main.rand.NextFloat(0.5f, 1f);
+
+		if (doDustSpawn)
+		{
+			for (int i = 0; i < 2; i++)
+			{
+				float mag = Main.rand.NextFloat();
+				var velocity = (Projectile.velocity * mag).RotatedByRandom(0.2f);
+				var color = Color.Lerp(Color.Black, new Color(255, 242, 200), mag) * 0.9f;
+
+				ParticleHandler.SpawnParticle(new MagicParticle(Projectile.Center, velocity * 0.75f, Color.OrangeRed, Main.rand.NextFloat(0.1f, 1f), Main.rand.Next(20, 200)));
+				ParticleHandler.SpawnParticle(new SmokeCloud(Projectile.Center + Vector2.Normalize(Projectile.velocity) * 10, velocity, color, Main.rand.NextFloat(0.05f, 0.1f), Common.Easing.EaseBuilder.EaseCircularInOut, Main.rand.Next(20, 60)));
+			}
+		}
+
+		if (Projectile.owner == Main.myPlayer)
+		{
+			const float range = 0.01f;
+
+			Projectile.ai[0] = Main.rand.NextFloat(-range, range);
+			Projectile.timeLeft = (int)(Projectile.timeLeft * Main.rand.NextFloat(randomTimeLeft.Item1, randomTimeLeft.Item2));
+
+			Projectile.netUpdate = true;
+		}
+
+		TrailManager.ManualTrailSpawn(Projectile);
 	}
 
 	public virtual void SpawnDust(Vector2 origin) => Dust.NewDustPerfect(origin, DustID.Torch, Projectile.velocity * 0.5f).noGravity = !Main.rand.NextBool(8);

--- a/Content/Forest/MagicPowder/VexpowderBlue.cs
+++ b/Content/Forest/MagicPowder/VexpowderBlue.cs
@@ -1,5 +1,6 @@
 ﻿using SpiritReforged.Common.Misc;
 using SpiritReforged.Common.Particle;
+using SpiritReforged.Common.PrimitiveRendering;
 using SpiritReforged.Content.Particles;
 using Terraria.Audio;
 
@@ -29,6 +30,21 @@ internal class VexpowderBlueDust : FlarepowderDust
 		randomTimeLeft = (0.2f, 0.4f);
 	}
 
+	public override void OnClientSpawn(bool doDustSpawn)
+	{
+		base.OnClientSpawn(false);
+
+		for (int i = 0; i < 2; i++)
+		{
+			float mag = Main.rand.NextFloat();
+			var velocity = (Projectile.velocity * mag).RotatedByRandom(0.2f);
+			var color = Color.Lerp(Colors[0], Colors[1], mag) * 3;
+
+			ParticleHandler.SpawnParticle(new MagicParticle(Projectile.Center, velocity * 0.75f, Colors[0], Main.rand.NextFloat(0.1f, 1f), Main.rand.Next(20, 200)));
+			ParticleHandler.SpawnParticle(new SmokeCloud(Projectile.Center + Vector2.Normalize(Projectile.velocity) * 10, velocity, color, Main.rand.NextFloat(0.05f, 0.1f), Common.Easing.EaseBuilder.EaseCircularInOut, Main.rand.Next(20, 60)));
+		}
+	}
+
 	public override void OnHitNPC(NPC target, NPC.HitInfo hit, int damageDone)
 	{
 		if (Main.rand.NextBool(3))
@@ -49,5 +65,7 @@ internal class VexpowderBlueDust : FlarepowderDust
 	{
 		SoundEngine.PlaySound(SoundID.DD2_LightningBugZap with { PitchRange = (1f, 1.5f), Volume = 0.6f, MaxInstances = 5 }, Projectile.Center);
 		SoundEngine.PlaySound(SoundID.DD2_DarkMageHealImpact with { Pitch = 0.9f }, Projectile.Center);
+
+		SoundEngine.PlaySound(Impact with { Pitch = 0.9f, Volume = 0.4f }, Projectile.Center);
 	}
 }

--- a/Content/Forest/MagicPowder/VexpowderBlue.cs
+++ b/Content/Forest/MagicPowder/VexpowderBlue.cs
@@ -1,6 +1,7 @@
 ﻿using SpiritReforged.Common.Misc;
 using SpiritReforged.Common.Particle;
 using SpiritReforged.Content.Particles;
+using Terraria.Audio;
 
 namespace SpiritReforged.Content.Forest.MagicPowder;
 
@@ -11,6 +12,8 @@ public class VexpowderBlue : Flarepowder
 		base.SetDefaults();
 		Item.shoot = ModContent.ProjectileType<VexpowderBlueDust>();
 		Item.damage = 10;
+		Item.crit = 2;
+		Item.shootSpeed = 6.2f;
 	}
 
 	public override void AddRecipes() => CreateRecipe(25).AddIngredient(ModContent.ItemType<Flarepowder>(), 25).AddIngredient(ItemID.VileMushroom).Register();
@@ -20,7 +23,18 @@ internal class VexpowderBlueDust : FlarepowderDust
 {
 	public override Color[] Colors => [Color.Violet, Color.BlueViolet, Color.Goldenrod];
 
-	public override void OnHitNPC(NPC target, NPC.HitInfo hit, int damageDone) => target.AddBuff(BuffID.Confused, 600);
+	public override void SetDefaults()
+	{
+		base.SetDefaults();
+		randomTimeLeft = (0.2f, 0.4f);
+	}
+
+	public override void OnHitNPC(NPC target, NPC.HitInfo hit, int damageDone)
+	{
+		if (Main.rand.NextBool(3))
+			target.AddBuff(BuffID.Confused, 150);
+	}
+
 	public override void OnKill(int timeLeft)
 	{
 		base.OnKill(timeLeft);
@@ -31,4 +45,9 @@ internal class VexpowderBlueDust : FlarepowderDust
 	}
 
 	public override void SpawnDust(Vector2 origin) => Dust.NewDustPerfect(origin, DustID.PurpleCrystalShard, Projectile.velocity * 0.5f).noGravity = true;
+	public override void PlayDeathSound()
+	{
+		SoundEngine.PlaySound(SoundID.DD2_LightningBugZap with { PitchRange = (1f, 1.5f), Volume = 0.6f, MaxInstances = 5 }, Projectile.Center);
+		SoundEngine.PlaySound(SoundID.DD2_DarkMageHealImpact with { Pitch = 0.9f }, Projectile.Center);
+	}
 }

--- a/Content/Forest/MagicPowder/VexpowderBlue.cs
+++ b/Content/Forest/MagicPowder/VexpowderBlue.cs
@@ -1,6 +1,5 @@
 ﻿using SpiritReforged.Common.Misc;
 using SpiritReforged.Common.Particle;
-using SpiritReforged.Common.PrimitiveRendering;
 using SpiritReforged.Content.Particles;
 using Terraria.Audio;
 

--- a/Content/Forest/MagicPowder/VexpowderRed.cs
+++ b/Content/Forest/MagicPowder/VexpowderRed.cs
@@ -7,6 +7,8 @@ public class VexpowderRed : Flarepowder
 		base.SetDefaults();
 		Item.shoot = ModContent.ProjectileType<VexpowderRedDust>();
 		Item.damage = 10;
+		Item.crit = 2;
+		Item.shootSpeed = 6.2f;
 	}
 
 	public override void AddRecipes() => CreateRecipe(25).AddIngredient(ModContent.ItemType<Flarepowder>(), 25).AddIngredient(ItemID.ViciousMushroom).Register();

--- a/Content/Underworld/Blasphemer/Blasphemer.cs
+++ b/Content/Underworld/Blasphemer/Blasphemer.cs
@@ -59,12 +59,14 @@ class BlasphemerProj : BaseClubProj, IManualTrailProjectile
 
 	public static readonly SoundStyle Swing1 = new("SpiritReforged/Assets/SFX/Item/FieryMaceSwing_1")
 	{
+		Volume = 0.6f,
 		PitchVariance = 0.2f,
 		PitchRange = (-0.4f, 0f)
 	};
 
 	public static readonly SoundStyle Swing2 = new("SpiritReforged/Assets/SFX/Item/FieryMaceSwing_2")
 	{
+		Volume = 0.6f,
 		PitchVariance = 0.2f,
 		PitchRange = (-0.4f, 0f)
 	};

--- a/Content/Underworld/Blasphemer/Firespike.cs
+++ b/Content/Underworld/Blasphemer/Firespike.cs
@@ -89,7 +89,7 @@ class Firespike : ModProjectile, IDrawOverTiles
 	private void Surface()
 	{
 		int surfaceDuration = 0;
-		while (WorldGen.SolidTile(GetOrigin()) || Main.tileSolidTop[Framing.GetTileSafely(GetOrigin()).TileType])
+		while (WorldGen.SolidTile(GetOrigin()))
 		{
 			Projectile.position.Y--; //Move out of solid tiles
 


### PR DESCRIPTION
- Changes the death sound of Vexpowder Dust
- Reduces Vexpowder debuff duration, increases crit chance by 2, and greatly reduces time to detonate
- Decreases the volume of Blasphemer and club ready sound effects
- Prevents Firespike from scaling solid-top tiles when attempting to find a surface