### PR TITLE
add emote helpers, breakaway chair makes npcs angry

### DIFF
--- a/Common/Misc/EmoteHelper.cs
+++ b/Common/Misc/EmoteHelper.cs
@@ -1,0 +1,130 @@
+﻿using SpiritReforged.Common.Multiplayer;
+using System.IO;
+using Terraria.GameContent.UI;
+
+namespace SpiritReforged.Common.Misc;
+
+internal static class EmoteHelper
+{
+	internal class SendNPCEmote : PacketData
+	{
+		private readonly byte _who;
+		private readonly short _time;
+		private readonly short _type;
+		private readonly byte _otherWhoType;
+		private readonly short _otherWho;
+
+		public SendNPCEmote() { }
+
+		/// <summary>
+		/// Creates a packet that sends <see cref="Emote(NPC, int, int, WorldUIAnchor)"/> with Main.npc[who], time, type, and other based on the given parameters.
+		/// </summary>
+		/// <param name="who">The whoAmI of the NPC to emote.</param>
+		/// <param name="time">The amount of time for the NPC to emote.</param>
+		/// <param name="type">The type of emote to use.</param>
+		/// <param name="otherWhoType"><see cref="byte.MaxValue"/> for no other; 0 for player, 1 for npc.</param>
+		/// <param name="otherWho">The whoAmI of the other entity. Unused if <see cref="_otherWhoType"/> is <see cref="byte.MaxValue"/>.</param>
+		public SendNPCEmote(byte who, short time, short type, byte otherWhoType = byte.MaxValue, short otherWho = 0)
+		{
+			_who = who;
+			_time = time;
+			_type = type;
+			_otherWho = otherWho;
+			_otherWhoType = otherWhoType;
+		}
+
+		public override void OnReceive(BinaryReader reader, int whoAmI)
+		{
+			byte who = reader.ReadByte();
+			short time = reader.ReadInt16();
+			short type = reader.ReadInt16();
+			byte otherWhoType = reader.ReadByte();
+			byte otherWho = 0;
+
+			if (otherWho != byte.MaxValue)
+			{
+				reader.ReadInt16();
+			}
+
+			Emote(Main.npc[who], time, type, otherWhoType == byte.MaxValue ? null : GetWorldAnchor(otherWhoType, otherWho));
+		}
+
+		private static WorldUIAnchor GetWorldAnchor(byte otherWhoType, byte otherWho)
+		{
+			if (otherWhoType == 0)
+				return new(Main.player[otherWho]);
+
+			if (otherWhoType == 1)
+				return new(Main.npc[otherWho]);
+
+			return null;
+		}
+
+		public override void OnSend(ModPacket modPacket)
+		{
+			modPacket.Write(_who);
+			modPacket.Write(_time);
+			modPacket.Write(_type);
+			modPacket.Write(_otherWhoType);
+
+			if (_otherWhoType != byte.MaxValue)
+				modPacket.Write(_otherWho);
+		}
+	}
+
+	/// <summary>
+	/// Makes an emote bubble for the given NPC that lasts <paramref name="emoteTime"/> of emote type <paramref name="emoteType"/>.<br/>
+	/// The NPC is used as the primary anchor.<br/>
+	/// This should not be called on multiplayer clients.
+	/// </summary>
+	/// <param name="npc">NPC to emote.</param>
+	/// <param name="emoteTime">How long, in ticks, the emote lasts.</param>
+	/// <param name="emoteType">The type of emote to use. See <see cref="EmoteID"/>.</param>
+	/// <param name="other">The other world anchor to use. <see cref="EmoteBubble.NewBubbleNPC(WorldUIAnchor, int, WorldUIAnchor)"/> describes this as:  
+	/// The <see cref="WorldUIAnchor"/> instance from the other side of the conversation. <b>This can only be an NPC anchor,</b> despite allowing any entity.</param>
+	public static void Emote(this NPC npc, int emoteTime, int emoteType, WorldUIAnchor other = null)
+	{
+		int oldNetMode = Main.netMode; // Vanilla forces it to sync if we're on the server, but we immediately need to sync it again.
+		Main.netMode = NetmodeID.SinglePlayer; // This skips the needless sync.
+
+		var bubbleAnchor = new WorldUIAnchor(npc);
+		int bubbleWho = EmoteBubble.NewBubbleNPC(bubbleAnchor, emoteTime, other);
+		var bubble = EmoteBubble.GetExistingEmoteBubble(bubbleWho);
+		bubble.emote = emoteType; // Override the emote type since NewBubbleNPC is only random for some reason.
+
+		Main.netMode = oldNetMode;
+
+		if (Main.netMode == NetmodeID.Server) // Properly sync the new bubble.
+		{
+			Tuple<int, int> tuple = EmoteBubble.SerializeNetAnchor(bubbleAnchor);
+			NetMessage.SendData(MessageID.SyncEmoteBubble, -1, -1, null, bubbleWho, tuple.Item1, tuple.Item2, emoteTime, bubble.emote, bubble.metadata);
+		}
+	}
+
+	/// <summary>
+	/// Calls <see cref="Emote(NPC, int, int, WorldUIAnchor)"/> on singleplayer/the server, or sends a <see cref="SendNPCEmote"/> packet if on a multiplayer client.
+	/// </summary>
+	/// <param name="npc">The NPC that is emoting.</param>
+	/// <param name="time">The amount of time that the NPC emotes.</param>
+	/// <param name="type">The type of emote to use.</param>
+	/// <param name="otherEntityAnchor">The other entity anchor to use, if any. 
+	/// This originally supported <see cref="Player"/> values, but vanilla doesn't account for it despite taking an Entity.</param>
+	public static void SyncedEmote(NPC npc, int time, int type, NPC otherEntityAnchor = null)
+	{
+		if (Main.netMode != NetmodeID.MultiplayerClient)
+			Emote(npc, time, type, otherEntityAnchor is null ? null : new WorldUIAnchor(otherEntityAnchor));
+		else
+		{
+			byte who = (byte)npc.whoAmI;
+
+			byte otherType = otherEntityAnchor switch
+			{
+				NPC => 1,
+				_ => byte.MaxValue,
+			};
+
+			byte otherWho = (byte)(otherType == byte.MaxValue ? 0 : otherEntityAnchor.whoAmI);
+			new SendNPCEmote(who, (short)time, (short)type, otherType, otherWho).Send();
+		}
+	}
+}

--- a/Common/NPCCommon/NPCHelper.cs
+++ b/Common/NPCCommon/NPCHelper.cs
@@ -1,4 +1,6 @@
-﻿namespace SpiritReforged.Common.NPCCommon;
+﻿using Terraria.GameContent.UI;
+
+namespace SpiritReforged.Common.NPCCommon;
 
 public static class NPCHelper
 {
@@ -37,7 +39,9 @@ public static class NPCHelper
 	}
 
 	public static void ImmuneTo<T>(ModNPC npc, params int[] buffs) where T : ModBuff => ImmuneTo(npc, [.. new List<int>(buffs) { ModContent.BuffType<T>() }]);
-	public static void ImmuneTo<T1, T2>(ModNPC npc, params int[] buffs) where T1 : ModBuff where T2 : ModBuff => ImmuneTo(npc, [.. new List<int>(buffs) { ModContent.BuffType<T1>(), ModContent.BuffType<T2>() }]);
+
+	public static void ImmuneTo<T1, T2>(ModNPC npc, params int[] buffs) where T1 : ModBuff where T2 : ModBuff 
+		=> ImmuneTo(npc, [.. new List<int>(buffs) { ModContent.BuffType<T1>(), ModContent.BuffType<T2>() }]);
 
 	public static void ImmuneTo<T1, T2, T3>(ModNPC npc, params int[] buffs) where T1 : ModBuff where T2 : ModBuff where T3 : ModBuff
 		=> ImmuneTo(npc, [.. new List<int>(buffs) { ModContent.BuffType<T1>(), ModContent.BuffType<T2>(), ModContent.BuffType<T3>() }]);

--- a/Content/Forest/Misc/ChairClub/BreakawayChairProj.cs
+++ b/Content/Forest/Misc/ChairClub/BreakawayChairProj.cs
@@ -5,6 +5,9 @@ using SpiritReforged.Common.PrimitiveRendering;
 using SpiritReforged.Common.ProjectileCommon.Abstract;
 using SpiritReforged.Content.Particles;
 using Terraria.Audio;
+using Terraria.GameContent.UI;
+using Terraria.ID;
+using SpiritReforged.Common.Misc;
 
 namespace SpiritReforged.Content.Forest.Misc.ChairClub;
 
@@ -84,8 +87,11 @@ class BreakawayChairProj : BaseClubProj, IManualTrailProjectile
 		ParticleHandler.SpawnParticle(new SmokeCloud(basePosition, directionUnit * 3, Color.LightGray, 0.06f * TotalScale, EaseFunction.EaseCubicOut, 30));
 		ParticleHandler.SpawnParticle(new SmokeCloud(basePosition, directionUnit * 6, Color.LightGray, 0.08f * TotalScale, EaseFunction.EaseCubicOut, 30));
 
+		if (target.isLikeATownNPC)
+			EmoteHelper.SyncedEmote(target, 60, EmoteID.EmoteAnger);
+
 		Projectile.Kill();
-		Main.player[Projectile.owner].HeldItem.stack--; //"Break" a stack of the chair
+		Main.player[Projectile.owner].HeldItem.stack--; // "Break" a stack of the chair
 
 		SoundEngine.PlaySound(SoundID.Dig, Projectile.Center);
 

--- a/Localization/pt-BR/Mods.SpiritReforged.Items.hjson
+++ b/Localization/pt-BR/Mods.SpiritReforged.Items.hjson
@@ -1987,26 +1987,26 @@ WickerBasketsItem: {
 }
 
 EarthshakerBreastplate: {
-	// DisplayName: Earthshaker Breastplate
+	// DisplayName: Earthshaker's Breastplate
 	// Tooltip: ""
 }
 
 EarthshakerChestpiece: {
-	// DisplayName: Earthshaker Chestpiece
+	// DisplayName: Earthshaker's Chestpiece
 	// Tooltip: ""
 }
 
 EarthshakerHeadgear: {
-	// DisplayName: Earthshaker Headgear
+	// DisplayName: Earthshaker's Headgear
 	// Tooltip: ""
 }
 
 EarthshakerTreads: {
-	// DisplayName: Earthshaker Treads
+	// DisplayName: Earthshaker's Treads
 	// Tooltip: ""
 }
 
 EarthshakerWarmask: {
-	// DisplayName: Earthshaker Warmask
+	// DisplayName: Earthshaker's Warmask
 	// Tooltip: ""
 }

--- a/Localization/ru-RU/Mods.SpiritReforged.Items.hjson
+++ b/Localization/ru-RU/Mods.SpiritReforged.Items.hjson
@@ -1979,26 +1979,26 @@ WickerBasketsItem: {
 }
 
 EarthshakerBreastplate: {
-	// DisplayName: Earthshaker Breastplate
+	// DisplayName: Earthshaker's Breastplate
 	// Tooltip: ""
 }
 
 EarthshakerChestpiece: {
-	// DisplayName: Earthshaker Chestpiece
+	// DisplayName: Earthshaker's Chestpiece
 	// Tooltip: ""
 }
 
 EarthshakerHeadgear: {
-	// DisplayName: Earthshaker Headgear
+	// DisplayName: Earthshaker's Headgear
 	// Tooltip: ""
 }
 
 EarthshakerTreads: {
-	// DisplayName: Earthshaker Treads
+	// DisplayName: Earthshaker's Treads
 	// Tooltip: ""
 }
 
 EarthshakerWarmask: {
-	// DisplayName: Earthshaker Warmask
+	// DisplayName: Earthshaker's Warmask
 	// Tooltip: ""
 }

--- a/Localization/zh-Hans/Mods.SpiritReforged.Items.hjson
+++ b/Localization/zh-Hans/Mods.SpiritReforged.Items.hjson
@@ -1987,26 +1987,26 @@ WickerBasketsItem: {
 }
 
 EarthshakerBreastplate: {
-	// DisplayName: Earthshaker Breastplate
+	// DisplayName: Earthshaker's Breastplate
 	// Tooltip: ""
 }
 
 EarthshakerChestpiece: {
-	// DisplayName: Earthshaker Chestpiece
+	// DisplayName: Earthshaker's Chestpiece
 	// Tooltip: ""
 }
 
 EarthshakerHeadgear: {
-	// DisplayName: Earthshaker Headgear
+	// DisplayName: Earthshaker's Headgear
 	// Tooltip: ""
 }
 
 EarthshakerTreads: {
-	// DisplayName: Earthshaker Treads
+	// DisplayName: Earthshaker's Treads
 	// Tooltip: ""
 }
 
 EarthshakerWarmask: {
-	// DisplayName: Earthshaker Warmask
+	// DisplayName: Earthshaker's Warmask
 	// Tooltip: ""
 }


### PR DESCRIPTION
- Adds in EmoteHelper to help make NPCs emote
- Adds in EmoteHelper.SendNPCEmote to sync it
- Breakaway Chair makes NPCs use the "Angry" emote when hit