### PR TITLE
Backpack hotkey interactions

### DIFF
--- a/Common/BuffCommon/BuffPlayer.cs
+++ b/Common/BuffCommon/BuffPlayer.cs
@@ -1,4 +1,5 @@
 ﻿using SpiritReforged.Common.PlayerCommon;
+using System.Linq;
 
 namespace SpiritReforged.Common.BuffCommon;
 
@@ -10,12 +11,34 @@ internal class BuffPlayer : ModPlayer
 	/// <param name="player"> The player this buff is being applied to. </param>
 	/// <param name="quickBuff"> Whether quick buff was used (<see cref="PlayerExtensions.UsedQuickBuff"/>). </param>
 	public delegate void ModifyBuffTimeDelegate(int buffType, ref int buffTime, Player player, bool quickBuff);
+	public delegate void QuickBuffDelegate(Player player);
 
 	/// <summary> Allows you to dynamically modify buff times before they are applied. </summary>
 	public static event ModifyBuffTimeDelegate ModifyBuffTime;
+	public static event QuickBuffDelegate QuickBuff;
 
 	/// <summary> Whether quick buff is being used. Only valid in specific methods, like <see cref="CombinedHooks.CanUseItem(Player, Item)"/>. </summary>
 	public bool usedQuickBuff;
+
+	public static bool CanHeal(Player player) => !player.cursed && !player.CCed && !player.dead && player.statLife != player.statLifeMax2 && player.potionDelay == 0;
+	public static IEnumerable<Item> SortByPriority(IEnumerable<Item> list, Player player, bool healing = false)
+	{
+		if (healing)
+		{
+			return list.OrderBy(x => player.GetHealLife(x, true));
+		}
+		else
+		{
+			return list.OrderBy(x => FindFoodPriority(x.buffType) + x.buffTime);
+		}
+	}
+
+	public static int FindFoodPriority(int type) => type switch
+	{
+		BuffID.WellFed2 => 1,
+		BuffID.WellFed3 => 2,
+		_ => 0
+	}; //Mimics a private vanilla method
 
 	public override void Load()
 	{
@@ -26,7 +49,10 @@ internal class BuffPlayer : ModPlayer
 	private static void TrackQuickBuff(On_Player.orig_QuickBuff orig, Player self)
 	{
 		self.GetModPlayer<BuffPlayer>().usedQuickBuff = true;
+		QuickBuff?.Invoke(self);
+
 		orig(self);
+
 		self.GetModPlayer<BuffPlayer>().usedQuickBuff = false;
 	}
 

--- a/Common/UI/BackpackInterface/BackpackUIState.cs
+++ b/Common/UI/BackpackInterface/BackpackUIState.cs
@@ -8,6 +8,8 @@ namespace SpiritReforged.Common.UI.BackpackInterface;
 
 internal class BackpackUIState : AutoUIState
 {
+	internal static bool HasPotionSlotMod { get; private set; }
+
 	private BackpackUISlot _functionalSlot;
 	private BackpackUISlot _vanitySlot;
 	private BackpackUISlot _dyeSlot;
@@ -17,6 +19,7 @@ internal class BackpackUIState : AutoUIState
 
 	public override void OnInitialize()
 	{
+		HasPotionSlotMod = ModLoader.HasMod("PotionSlots");
 		Width = Height = StyleDimension.Fill;
 
 		_functionalSlot = new BackpackUISlot(false);
@@ -39,9 +42,7 @@ internal class BackpackUIState : AutoUIState
 	private static void TryOpenUI(On_Main.orig_DrawInventory orig, Main self)
 	{
 		orig(self);
-
-		if (Main.playerInventory)
-			UISystem.SetActive<BackpackUIState>();
+		UISystem.SetActive<BackpackUIState>();
 	}
 
 	public override void Update(GameTime gameTime)
@@ -99,12 +100,7 @@ internal class BackpackUIState : AutoUIState
 		if (!clear)
 		{
 			const float spacing = 33.5f;
-			int baseX = 571;
-
-			if (ModLoader.HasMod("PotionSlots"))
-			{
-				baseX += 38;
-			}
+			int baseX = HasPotionSlotMod ? 609 : 571;
 
 			int xOff = 0, yOff = 0;
 
@@ -131,9 +127,7 @@ internal class BackpackUIState : AutoUIState
 					Height = StyleDimension.FromPixels(32)
 				};
 
-				yOff++;
-
-				if (yOff >= 4)
+				if (++yOff >= 4)
 				{
 					xOff++;
 					yOff = 0;

--- a/Content/Savanna/Items/Gar/QuenchPotion.cs
+++ b/Content/Savanna/Items/Gar/QuenchPotion.cs
@@ -11,30 +11,28 @@ public class QuenchPotion : ModItem
 	#region detours
 	public override void Load()
 	{
-		On_Player.QuickBuff += FocusQuenchPotion;
+		BuffPlayer.QuickBuff += FocusQuenchPotion;
 		BuffPlayer.ModifyBuffTime += QuenchifyBuff;
 	}
 
 	/// <summary> Forces this potion to be used before all others with quick buff. </summary>
-	private static void FocusQuenchPotion(On_Player.orig_QuickBuff orig, Player self)
+	private static void FocusQuenchPotion(Player player)
 	{
-		if (!self.cursed && !self.CCed && !self.dead && !self.HasBuff(BuffType) && self.CountBuffs() < Player.MaxBuffs)
+		if (!player.cursed && !player.CCed && !player.dead && !player.HasBuff(BuffType) && player.CountBuffs() < Player.MaxBuffs)
 		{
-			int itemIndex = self.FindItemInInventoryOrOpenVoidBag(ModContent.ItemType<QuenchPotion>(), out bool inVoidBag);
+			int itemIndex = player.FindItemInInventoryOrOpenVoidBag(ModContent.ItemType<QuenchPotion>(), out bool inVoidBag);
 
 			if (itemIndex > 0)
 			{
-				var item = inVoidBag ? self.bank4.item[itemIndex] : self.inventory[itemIndex];
+				var item = inVoidBag ? player.bank4.item[itemIndex] : player.inventory[itemIndex];
 
-				ItemLoader.UseItem(item, self);
-				self.AddBuff(item.buffType, item.buffTime);
+				ItemLoader.UseItem(item, player);
+				player.AddBuff(item.buffType, item.buffTime);
 
-				if (item.consumable && ItemLoader.ConsumeItem(item, self) && --item.stack <= 0)
+				if (item.consumable && ItemLoader.ConsumeItem(item, player) && --item.stack <= 0)
 					item.TurnToAir();
 			}
 		}
-
-		orig(self);
 	}
 
 	/// <summary> Improves buff times with <see cref="QuenchPotion_Buff"/>. </summary>


### PR DESCRIPTION
Allows potions and food items to be selected from backpack slots using quick buff and quick heal.