### PR TITLE
Tile reflection settings

### DIFF
--- a/Common/ConfigurationCommon/ReforgedClientConfig.cs
+++ b/Common/ConfigurationCommon/ReforgedClientConfig.cs
@@ -4,14 +4,16 @@ using Terraria.ModLoader.Config;
 
 namespace SpiritReforged.Common.ConfigurationCommon;
 
-class ReforgeClientConfig : ModConfig
+class ReforgedClientConfig : ModConfig
 {
 	public override ConfigScope Mode => ConfigScope.ClientSide;
 
 	[DefaultValue(OceanGeneration.OceanShape.Piecewise_V)]
 	public OceanGeneration.OceanShape OceanShape { get; set; }
 
-	//[ReloadRequired]
-	//[DefaultValue(true)]
-	//public bool SurfaceWaterTransparency { get; set; }
+	[Range(0, 3)]
+	[DrawTicks]
+	[Slider]
+	[DefaultValue(2)]
+	public int ReflectionDetail { get; set; }
 }

--- a/Common/Visuals/RenderTargets/ModTarget2D.cs
+++ b/Common/Visuals/RenderTargets/ModTarget2D.cs
@@ -42,6 +42,15 @@ public class ModTarget2D : ILoadable
 		Targets.Add(this);
 	}
 
+	/// <summary> Resizes <see cref="Target"/> to <paramref name="size"/>. Automatically queued on the main thread. </summary>
+	public void Resize(Vector2 size) => Main.QueueMainThreadAction(() =>
+	{
+		var gd = Main.instance.GraphicsDevice;
+
+		Target.Dispose();
+		Target = new RenderTarget2D(gd, (int)size.X, (int)size.Y, false, SurfaceFormat.Color, DepthFormat.None, 0, RenderTargetUsage.PreserveContents);
+	});
+
 	/// <summary> Draws the contents of <see cref="DrawInto(SpriteBatch)"/> and automatically handles <paramref name="spriteBatch"/> modes.<br/>
 	/// Check <see cref="Active"/> before calling this method. </summary>
 	public virtual void Prepare(SpriteBatch spriteBatch) //You don't normally need to override this

--- a/Common/Visuals/RenderTargets/TargetSetup.cs
+++ b/Common/Visuals/RenderTargets/TargetSetup.cs
@@ -1,5 +1,7 @@
 ﻿namespace SpiritReforged.Common.Visuals.RenderTargets;
 
+/// <summary> Handles <see cref="ModTarget2D"/> hooks. Does not exist on the server. </summary>
+[Autoload(Side = ModSide.Client)]
 internal class TargetSetup : ILoadable
 {
 	/// <summary> Called with <see cref="On_Main.CheckMonoliths"/>. </summary>
@@ -16,8 +18,8 @@ internal class TargetSetup : ILoadable
 		};
 
 		DrawIntoRendertargets += DrawIntoTargets;
+		Main.OnResolutionChanged += ResizeAll;
 	}
-	public void Unload() { }
 
 	private static void DrawIntoTargets()
 	{
@@ -27,4 +29,15 @@ internal class TargetSetup : ILoadable
 				target.Prepare(Main.spriteBatch);
 		}
 	}
+
+	private static void ResizeAll(Vector2 obj)
+	{
+		foreach (var t in ModTarget2D.Targets)
+		{
+			var viewport = Main.instance.GraphicsDevice.Viewport;
+			t.Resize(new(viewport.Width, viewport.Height));
+		}
+	}
+
+	public void Unload() => Main.OnResolutionChanged -= ResizeAll;
 }

--- a/Content/Ocean/OceanGeneration.cs
+++ b/Content/Ocean/OceanGeneration.cs
@@ -6,7 +6,6 @@ using SpiritReforged.Common.ConfigurationCommon;
 using SpiritReforged.Content.Ocean.Items;
 using SpiritReforged.Common.WorldGeneration;
 using Terraria.Utilities;
-using SpiritReforged.Common.ModCompat.Classic;
 using SpiritReforged.Common.ModCompat;
 
 namespace SpiritReforged.Content.Ocean;
@@ -22,7 +21,7 @@ public class OceanGeneration : ModSystem
 
 	public override void ModifyWorldGenTasks(List<GenPass> tasks, ref double totalWeight)
 	{
-        if (ModContent.GetInstance<ReforgeClientConfig>().OceanShape != OceanShape.Default)
+        if (ModContent.GetInstance<ReforgedClientConfig>().OceanShape != OceanShape.Default)
         {
             int beachIndex = tasks.FindIndex(genpass => genpass.Name.Equals("Beaches")); //Replace beach gen
             if (beachIndex != -1)
@@ -462,7 +461,7 @@ public class OceanGeneration : ModSystem
 	/// <param name="tilesFromInnerEdge"></param>
 	private static float GetOceanSlope(int tilesFromInnerEdge)
 	{
-		OceanShape shape = ModContent.GetInstance<ReforgeClientConfig>().OceanShape;
+		OceanShape shape = ModContent.GetInstance<ReforgedClientConfig>().OceanShape;
 
 		if (shape == OceanShape.SlantedSine)
 		{

--- a/Content/SaltFlats/Tiles/Salt/SaltBlock.cs
+++ b/Content/SaltFlats/Tiles/Salt/SaltBlock.cs
@@ -78,7 +78,9 @@ public class SaltBlockReflective : SaltBlock
 
 	public override bool PreDraw(int i, int j, SpriteBatch spriteBatch)
 	{
-		SaltBlockVisuals.ReflectionPoints.Add(new(i, j));
+		if (SaltBlockVisuals.Enabled)
+			SaltBlockVisuals.ReflectionPoints.Add(new(i, j));
+
 		return true;
 	}
 }

--- a/Localization/en-US/Mods.SpiritReforged.Configs.hjson
+++ b/Localization/en-US/Mods.SpiritReforged.Configs.hjson
@@ -1,5 +1,5 @@
-ReforgeClientConfig: {
-	DisplayName: Reforge Client Config
+ReforgedClientConfig: {
+	DisplayName: Reforged Client Config
 
 	OceanShape: {
 		Label: Ocean Shape
@@ -11,12 +11,12 @@ ReforgeClientConfig: {
 			'''
 	}
 
-	SurfaceWaterTransparency: {
-		Label: Surface Water Transparency
+	ReflectionDetail: {
+		Label: Reflection Detail
 		Tooltip:
 			'''
-			Allows for transparent ocean water when on
-			This does not affect any other biome
+			Determines the detail of all reflections
+			Higher values mean more detail and a greater resulting performance cost
 			'''
 	}
 }
@@ -47,4 +47,17 @@ ReforgedServerConfig: {
 		Label: Floating Item Cap
 		Tooltip: Determines how many floating items can be active in the world at one time.
 	}
+}
+
+Details: {
+	Tooltip: ""
+	Background.Label: Background
+	Tiles.Label: Tiles
+	Water.Label: Water
+	NPCs.Label: N P Cs
+	Gores.Label: Gores
+	Dusts.Label: Dusts
+	Items.Label: Items
+	Projectiles.Label: Projectiles
+	Players.Label: Players
 }

--- a/Localization/en-US/Mods.SpiritReforged.Configs.hjson
+++ b/Localization/en-US/Mods.SpiritReforged.Configs.hjson
@@ -48,16 +48,3 @@ ReforgedServerConfig: {
 		Tooltip: Determines how many floating items can be active in the world at one time.
 	}
 }
-
-Details: {
-	Tooltip: ""
-	Background.Label: Background
-	Tiles.Label: Tiles
-	Water.Label: Water
-	NPCs.Label: N P Cs
-	Gores.Label: Gores
-	Dusts.Label: Dusts
-	Items.Label: Items
-	Projectiles.Label: Projectiles
-	Players.Label: Players
-}

--- a/Localization/pt-BR/Mods.SpiritReforged.Configs.hjson
+++ b/Localization/pt-BR/Mods.SpiritReforged.Configs.hjson
@@ -48,16 +48,3 @@ ReforgedServerConfig: {
 		Tooltip: Determina quantos itens flutuantes podem estar ativos no mundo ao mesmo tempo.
 	}
 }
-
-Details: {
-	// Tooltip: ""
-	// Background.Label: Background
-	// Tiles.Label: Tiles
-	// Water.Label: Water
-	// NPCs.Label: N P Cs
-	// Gores.Label: Gores
-	// Dusts.Label: Dusts
-	// Items.Label: Items
-	// Projectiles.Label: Projectiles
-	// Players.Label: Players
-}

--- a/Localization/pt-BR/Mods.SpiritReforged.Configs.hjson
+++ b/Localization/pt-BR/Mods.SpiritReforged.Configs.hjson
@@ -1,23 +1,23 @@
-ReforgeClientConfig: {
-	DisplayName: Configuração do Cliente do Reforged
+ReforgedClientConfig: {
+	// DisplayName: Reforged Client Config
 
 	OceanShape: {
-		Label: Forma do Oceano
-		Tooltip:
+		// Label: Ocean Shape
+		/* Tooltip:
 			'''
-			Modifica a geração do oceano de algumas maneiras
-			O padrão é a geração Piecewise_V
-			A geração Piecewise_V é recomendada para jogatinas com o Espírito
-			'''
+			Modifies the Ocean generation in certain ways
+			Defaults to a Piecewise_V generation
+			The Piecewise_V generation is recommended for Spirit playthroughs
+			''' */
 	}
 
-	SurfaceWaterTransparency: {
-		Label: Transparência da Água da Superfície
-		Tooltip:
+	ReflectionDetail: {
+		// Label: Reflection Detail
+		/* Tooltip:
 			'''
-			Permite que a água do oceano seja transparente quando ativado
-			Isso não afeta nenhum outro bioma
-			'''
+			Determines the detail of all reflections
+			Higher values mean more detail and a greater resulting performance cost
+			''' */
 	}
 }
 
@@ -47,4 +47,17 @@ ReforgedServerConfig: {
 		Label: Limite de Itens Flutuantes
 		Tooltip: Determina quantos itens flutuantes podem estar ativos no mundo ao mesmo tempo.
 	}
+}
+
+Details: {
+	// Tooltip: ""
+	// Background.Label: Background
+	// Tiles.Label: Tiles
+	// Water.Label: Water
+	// NPCs.Label: N P Cs
+	// Gores.Label: Gores
+	// Dusts.Label: Dusts
+	// Items.Label: Items
+	// Projectiles.Label: Projectiles
+	// Players.Label: Players
 }

--- a/Localization/ru-RU/Mods.SpiritReforged.Configs.hjson
+++ b/Localization/ru-RU/Mods.SpiritReforged.Configs.hjson
@@ -48,16 +48,3 @@ ReforgedServerConfig: {
 		Tooltip: Ограничивает количество предметов, которые могут плавать на поверхности воды одновременно.
 	}
 }
-
-Details: {
-	// Tooltip: ""
-	// Background.Label: Background
-	// Tiles.Label: Tiles
-	// Water.Label: Water
-	// NPCs.Label: N P Cs
-	// Gores.Label: Gores
-	// Dusts.Label: Dusts
-	// Items.Label: Items
-	// Projectiles.Label: Projectiles
-	// Players.Label: Players
-}

--- a/Localization/ru-RU/Mods.SpiritReforged.Configs.hjson
+++ b/Localization/ru-RU/Mods.SpiritReforged.Configs.hjson
@@ -1,23 +1,23 @@
-ReforgeClientConfig: {
-	DisplayName: Клиентская конфигурация
+ReforgedClientConfig: {
+	// DisplayName: Reforged Client Config
 
 	OceanShape: {
-		Label: Генерация океана
-		Tooltip:
+		// Label: Ocean Shape
+		/* Tooltip:
 			'''
-			Изменяет генерацию океана различными способами
-			По умолчанию используется схема "Составная V"
-			Рекомендуется для прохождений с модом Spirit
-			'''
+			Modifies the Ocean generation in certain ways
+			Defaults to a Piecewise_V generation
+			The Piecewise_V generation is recommended for Spirit playthroughs
+			''' */
 	}
 
-	SurfaceWaterTransparency: {
-		Label: Прозрачность воды в океане
-		Tooltip:
+	ReflectionDetail: {
+		// Label: Reflection Detail
+		/* Tooltip:
 			'''
-			Позволяет сделать воду в океане прозрачной
-			Не влияет на другие биомы
-			'''
+			Determines the detail of all reflections
+			Higher values mean more detail and a greater resulting performance cost
+			''' */
 	}
 }
 
@@ -47,4 +47,17 @@ ReforgedServerConfig: {
 		Label: Лимит плавающих предметов
 		Tooltip: Ограничивает количество предметов, которые могут плавать на поверхности воды одновременно.
 	}
+}
+
+Details: {
+	// Tooltip: ""
+	// Background.Label: Background
+	// Tiles.Label: Tiles
+	// Water.Label: Water
+	// NPCs.Label: N P Cs
+	// Gores.Label: Gores
+	// Dusts.Label: Dusts
+	// Items.Label: Items
+	// Projectiles.Label: Projectiles
+	// Players.Label: Players
 }

--- a/Localization/zh-Hans/Mods.SpiritReforged.Configs.hjson
+++ b/Localization/zh-Hans/Mods.SpiritReforged.Configs.hjson
@@ -48,16 +48,3 @@ ReforgedServerConfig: {
 		Tooltip: 影响一个世界内同时可以有多少漂浮物。
 	}
 }
-
-Details: {
-	// Tooltip: ""
-	// Background.Label: Background
-	// Tiles.Label: Tiles
-	// Water.Label: Water
-	// NPCs.Label: N P Cs
-	// Gores.Label: Gores
-	// Dusts.Label: Dusts
-	// Items.Label: Items
-	// Projectiles.Label: Projectiles
-	// Players.Label: Players
-}

--- a/Localization/zh-Hans/Mods.SpiritReforged.Configs.hjson
+++ b/Localization/zh-Hans/Mods.SpiritReforged.Configs.hjson
@@ -1,23 +1,23 @@
-ReforgeClientConfig: {
-	DisplayName: 魂灵新魄客户端配置
+ReforgedClientConfig: {
+	// DisplayName: Reforged Client Config
 
 	OceanShape: {
-		Label: 海洋：海洋生成形状
-		Tooltip:
+		// Label: Ocean Shape
+		/* Tooltip:
 			'''
-			以某些方式修改海洋生成
-			默认为分段_V生成
-			仅推荐在游玩魂灵模组时使用分段_V生成
-			'''
+			Modifies the Ocean generation in certain ways
+			Defaults to a Piecewise_V generation
+			The Piecewise_V generation is recommended for Spirit playthroughs
+			''' */
 	}
 
-	SurfaceWaterTransparency: {
-		Label: 海洋：海水透明度
-		Tooltip:
+	ReflectionDetail: {
+		// Label: Reflection Detail
+		/* Tooltip:
 			'''
-			启用后，允许海水透明
-			不会影响任其他生物群落
-			'''
+			Determines the detail of all reflections
+			Higher values mean more detail and a greater resulting performance cost
+			''' */
 	}
 }
 
@@ -47,4 +47,17 @@ ReforgedServerConfig: {
 		Label: 漂浮物上限
 		Tooltip: 影响一个世界内同时可以有多少漂浮物。
 	}
+}
+
+Details: {
+	// Tooltip: ""
+	// Background.Label: Background
+	// Tiles.Label: Tiles
+	// Water.Label: Water
+	// NPCs.Label: N P Cs
+	// Gores.Label: Gores
+	// Dusts.Label: Dusts
+	// Items.Label: Items
+	// Projectiles.Label: Projectiles
+	// Players.Label: Players
 }


### PR DESCRIPTION
- Adds config presets to change how reflections look on tiles
- Adds the ability for reflections to capture dusts, gores, projectiles and items on the highest preset
- Fixes reflections crashing the game on retro lighting modes
- Fixes `ModTarget2D` instances not resizing correctly