### PR TITLE
see changelog

### DIFF
--- a/Common/Multiplayer/MultiplayerHandler.cs
+++ b/Common/Multiplayer/MultiplayerHandler.cs
@@ -28,7 +28,9 @@ internal class MultiplayerHandler : ILoadable
 
 		if (PacketTypes.TryGetValue(id, out var data))
 		{
-			SpiritReforgedMod.Instance.Logger.Debug("[Synchronization] Reading incoming: " + data.GetType().Name);
+			if (data.Log)
+				SpiritReforgedMod.Instance.Logger.Debug("[Synchronization] Reading incoming: " + data.GetType().Name);
+
 			data.OnReceive(reader, whoAmI);
 		}
 		else

--- a/Common/Multiplayer/PacketData.cs
+++ b/Common/Multiplayer/PacketData.cs
@@ -7,6 +7,11 @@ namespace SpiritReforged.Common.Multiplayer;
 /// Must include a parameterless constructor for initialization purposes. </summary>
 internal abstract class PacketData
 {
+	/// <summary>
+	/// Whether this packet will be logged. True by default.
+	/// </summary>
+	public virtual bool Log => true;
+
 	/// <summary> This must be called after creating a new packet instance in order for it to be sent. </summary>
 	public void Send(int toClient = -1, int ignoreClient = -1)
 	{

--- a/Common/PlayerCommon/PlayerMouseHandler.cs
+++ b/Common/PlayerCommon/PlayerMouseHandler.cs
@@ -7,6 +7,8 @@ internal class PlayerMouseHandler
 {
 	internal class ShareMouseData : PacketData
 	{
+		public override bool Log => false;
+
 		private readonly byte _playerWho;
 		private readonly Vector2 _mouse;
 

--- a/Content/Underground/Items/BombCannon.cs
+++ b/Content/Underground/Items/BombCannon.cs
@@ -34,7 +34,12 @@ public class BombCannon : ModItem
 
 	public override void SetStaticDefaults()
 	{
-		ItemEvents.CreateItemDefaults(item => item.ammo = ItemID.Bomb, AmmoBombIDs);
+		ItemEvents.CreateItemDefaults(item =>
+		{
+			item.ammo = ItemID.Bomb;
+			item.notAmmo = true;
+		}, AmmoBombIDs);
+
 		NPCShopHelper.AddEntry(new NPCShopHelper.ConditionalEntry((shop) => shop.NpcType == NPCID.Demolitionist, new NPCShop.Entry(Type, Condition.DownedEarlygameBoss)));
 		MoRHelper.AddElement(Item, MoRHelper.Explosive, true);
 	}

--- a/Content/Underground/Items/ClayBomb.cs
+++ b/Content/Underground/Items/ClayBomb.cs
@@ -8,6 +8,7 @@ public class ClayBomb : ModItem
 	{
 		Item.CloneDefaults(ItemID.DirtBomb);
 		Item.shoot = ModContent.ProjectileType<ClayBombProjectile>();
+		Item.notAmmo = true;
 	}
 
 	public override void AddRecipes() => CreateRecipe().AddIngredient(ItemID.Bomb).AddIngredient(ItemID.ClayBlock, 25).Register();

--- a/Content/Underground/Items/ClayBombSticky.cs
+++ b/Content/Underground/Items/ClayBombSticky.cs
@@ -6,6 +6,7 @@ public class ClayBombSticky : ModItem
 	{
 		Item.CloneDefaults(ItemID.DirtBomb);
 		Item.shoot = ModContent.ProjectileType<ClayBombStickyProjectile>();
+		Item.notAmmo = true;
 	}
 
 	public override void AddRecipes() => CreateRecipe().AddIngredient(ItemID.StickyBomb).AddIngredient(ItemID.ClayBlock, 25).Register();

--- a/Content/Underground/Items/CoarseBomb.cs
+++ b/Content/Underground/Items/CoarseBomb.cs
@@ -10,6 +10,7 @@ public class CoarseBomb : ModItem
 	{
 		Item.CloneDefaults(ItemID.DirtBomb);
 		Item.shoot = ModContent.ProjectileType<CoarseBombProjectile>();
+		Item.notAmmo = true;
 	}
 
 	public override void AddRecipes() => CreateRecipe().AddIngredient(ItemID.Bomb).AddIngredient(AutoContent.ItemType<SavannaDirt>(), 25).Register();

--- a/Content/Underground/Items/CoarseBombSticky.cs
+++ b/Content/Underground/Items/CoarseBombSticky.cs
@@ -9,6 +9,7 @@ public class CoarseBombSticky : ModItem
 	{
 		Item.CloneDefaults(ItemID.DirtBomb);
 		Item.shoot = ModContent.ProjectileType<CoarseBombStickyProjectile>();
+		Item.notAmmo = true;
 	}
 
 	public override void AddRecipes() => CreateRecipe().AddIngredient(ItemID.StickyBomb).AddIngredient(AutoContent.ItemType<SavannaDirt>(), 25).Register();

--- a/Content/Underground/Items/FingerGun/FingerGun.cs
+++ b/Content/Underground/Items/FingerGun/FingerGun.cs
@@ -93,7 +93,7 @@ public class FingerGunArmManager : ModPlayer
 		// and tends to look almost 1:1 unless you really stare at it.
 		Vector2 mouse = Main.myPlayer == Player.whoAmI ? Main.MouseWorld : PlayerMouseHandler.MouseByWhoAmI[Player.whoAmI];
 
-		if (Player.ItemAnimationJustStarted) // Spawn these here instead of in ModifyShootStats since this runs on all clients
+		if (Player.ItemAnimationJustStarted && !Main.dedServ) // Spawn these here instead of in ModifyShootStats since this runs on all clients
 		{
 			Vector2 velocity = Player.DirectionTo(mouse) * Player.HeldItem.shootSpeed;
 			Vector2 handPos = Player.GetFrontHandPosition(Player.CompositeArmStretchAmount.Full, velocity.ToRotation() - MathHelper.PiOver2);

--- a/Content/Underground/Items/MudBomb.cs
+++ b/Content/Underground/Items/MudBomb.cs
@@ -8,6 +8,7 @@ public class MudBomb : ModItem
 	{
 		Item.CloneDefaults(ItemID.DirtBomb);
 		Item.shoot = ModContent.ProjectileType<MudBombProjectile>();
+		Item.notAmmo = true;
 	}
 
 	public override void AddRecipes() => CreateRecipe().AddIngredient(ItemID.Bomb).AddIngredient(ItemID.MudBlock, 25).Register();

--- a/Content/Underground/Items/MudBombSticky.cs
+++ b/Content/Underground/Items/MudBombSticky.cs
@@ -6,6 +6,7 @@ public class MudBombSticky : ModItem
 	{
 		Item.CloneDefaults(ItemID.DirtBomb);
 		Item.shoot = ModContent.ProjectileType<MudBombStickyProjectile>();
+		Item.notAmmo = true;
 	}
 
 	public override void AddRecipes() => CreateRecipe().AddIngredient(ItemID.StickyBomb).AddIngredient(ItemID.MudBlock, 25).Register();

--- a/Content/Underground/Items/SandBomb.cs
+++ b/Content/Underground/Items/SandBomb.cs
@@ -8,6 +8,7 @@ public class SandBomb : ModItem
 	{
 		Item.CloneDefaults(ItemID.DirtBomb);
 		Item.shoot = ModContent.ProjectileType<SandBombProjectile>();
+		Item.notAmmo = true;
 	}
 
 	public override void AddRecipes() => CreateRecipe().AddIngredient(ItemID.Bomb).AddIngredient(ItemID.SandBlock, 25).Register();

--- a/Content/Underground/Items/SandBombSticky.cs
+++ b/Content/Underground/Items/SandBombSticky.cs
@@ -6,6 +6,7 @@ public class SandBombSticky : ModItem
 	{
 		Item.CloneDefaults(ItemID.DirtBomb);
 		Item.shoot = ModContent.ProjectileType<SandBombStickyProjectile>();
+		Item.notAmmo = true;
 	}
 
 	public override void AddRecipes() => CreateRecipe().AddIngredient(ItemID.StickyBomb).AddIngredient(ItemID.SandBlock, 25).Register();

--- a/Content/Underground/NPCs/DunceCrab.cs
+++ b/Content/Underground/NPCs/DunceCrab.cs
@@ -171,7 +171,7 @@ public class DunceCrab : ModNPC
 	{
 		if (NPC.collideY || NPC.velocity.Y == 0)
 		{
-			if ((State)Animation != State.Flail)
+			if ((State)Animation != State.Flail && !Main.dedServ)
 			{
 				Collision.HitTiles(NPC.position, NPC.velocity, NPC.width, NPC.height);
 
@@ -184,6 +184,12 @@ public class DunceCrab : ModNPC
 
 			ChangeState(State.Flail);
 			NPC.velocity = Vector2.Zero;
+
+			if (!Collision.SolidCollision(NPC.BottomLeft, NPC.width, 8)) // Fall if not actually embedded
+			{
+				ChangeState(State.Fall);
+				NPC.velocity.Y = 0.1f;
+			}
 		}
 		else
 		{

--- a/build.txt
+++ b/build.txt
@@ -1,6 +1,6 @@
 displayName = Spirit Reforged
 author = Team Spirit
-version = 0.1.2.1
+version = 0.1.2.2
 dllReferences = NPCUtils, StructureHelper, RubbleAutoloader, ILLogger
 modReferences = SpiritMusic
 buildIgnore = Assets/Shaders/*.dll

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,10 +1,6 @@
-v0.1.2.1
-- Updated Chinese localization
-- Fixed Acacia platforms causing timeouts when trying to sync in multiplayer
-- Added Flarepowder to surface and underground pot drop pools
-- Fixed tooltip inconsistencies for Radon and Oganesson mosses
-- Added Potion of Return as a decorative Potion Vat potion with the color, in RGB, 129, 111, 179
-- Fixed herbs not showing as their full stage with the Botanist armor set's highlight
-- Changed Botanist highlight to green for visibility
-- Added basic wind sway to Botanist armor set highlights (but not push)
-- Added "PlayerBotanist" Mod Call to allow for crossmod herb highlighting
+v0.1.2.2
+- Made all bombs not show up as ammo, not go into ammo slots
+- Fixed Finger Blaster issue in mp
+- Fixed Dunce Crabs embedding into air if the ground under them is mined out
+- Fixed Dunce Crabs being desynced by a server issue
+- Stopped ShareMouseData packet from noting sync in mp, spamming log


### PR DESCRIPTION
- Made all bombs not show up as ammo, not go into ammo slots
- Fixed Finger Blaster issue in mp
- Fixed Dunce Crabs embedding into air if the ground under them is mined out
- Fixed Dunce Crabs being desynced by a server issue
- Stopped ShareMouseData packet from noting sync in mp, spamming log