### PR TITLE
QA Pass

### DIFF
--- a/Content/Desert/NPCs/Beetle/GoldDivingBeetle.cs
+++ b/Content/Desert/NPCs/Beetle/GoldDivingBeetle.cs
@@ -15,6 +15,7 @@ public class GoldDivingBeetle : DivingBeetle, IGoldCritter
 		{
 			item.value = Item.sellPrice(0, 10, 0, 0);
 			item.bait = 50;
+			item.rare = ItemRarityID.Orange;
 		}
 	);
 }

--- a/Content/Forest/Misc/CraneFeather.cs
+++ b/Content/Forest/Misc/CraneFeather.cs
@@ -1,10 +1,18 @@
+using SpiritReforged.Common.ItemCommon;
 using SpiritReforged.Common.ModCompat.Classic;
+using Terraria.GameContent.ItemDropRules;
 
 namespace SpiritReforged.Content.Forest.Misc;
 
 [FromClassic("SwiftRune")]
 public class CraneFeather : ModItem
 {
+	public override void SetStaticDefaults()
+	{
+		ItemLootDatabase.AddItemRule(ItemID.WoodenCrate, ItemDropRule.Common(Type, 20));
+		ItemLootDatabase.AddItemRule(ItemID.WoodenCrateHard, ItemDropRule.Common(Type, 20));
+	}
+
 	public override void SetDefaults()
 	{
 		Item.width = 30;

--- a/Content/Forest/RoguesCrest/RogueCrest.cs
+++ b/Content/Forest/RoguesCrest/RogueCrest.cs
@@ -12,8 +12,8 @@ public class RogueCrest : MinionAccessory
 
 	public override void StaticDefaults()
 	{
-		ItemLootDatabase.AddItemRule(ItemID.WoodenCrate, ItemDropRule.Common(Type, 8));
-		ItemLootDatabase.AddItemRule(ItemID.WoodenCrateHard, ItemDropRule.Common(Type, 8));
+		ItemLootDatabase.AddItemRule(ItemID.WoodenCrate, ItemDropRule.Common(Type, 20));
+		ItemLootDatabase.AddItemRule(ItemID.WoodenCrateHard, ItemDropRule.Common(Type, 20));
 	}
 
 	public override void Defaults()

--- a/Content/Granite/Vanity/HardlightVisor.cs
+++ b/Content/Granite/Vanity/HardlightVisor.cs
@@ -1,5 +1,7 @@
 using SpiritReforged.Common.ModCompat;
+using SpiritReforged.Common.NPCCommon;
 using SpiritReforged.Common.Visuals.Glowmasks;
+using Terraria.GameContent.ItemDropRules;
 
 namespace SpiritReforged.Content.Granite.Vanity;
 
@@ -12,7 +14,12 @@ public class HardlightVisor : ModItem
 	public override LocalizedText DisplayName => CrossMod.Redemption.Enabled ? Language.GetText(Common + "AltDisplayName") : base.DisplayName;
 	public override LocalizedText Tooltip => CrossMod.Redemption.Enabled ? Language.GetText(Common + "AltTooltip") : base.Tooltip;
 
-	public override void SetStaticDefaults() => ArmorIDs.Head.Sets.DrawFullHair[Item.headSlot] = true;
+	public override void SetStaticDefaults()
+	{
+		ArmorIDs.Head.Sets.DrawFullHair[Item.headSlot] = true;
+		NPCLootDatabase.AddLoot(new(NPCLootDatabase.MatchId(NPCID.GraniteFlyer), ItemDropRule.Common(Type, 50)));
+		NPCLootDatabase.AddLoot(new(NPCLootDatabase.MatchId(NPCID.GraniteGolem), ItemDropRule.Common(Type, 50)));
+	}
 
 	public override void SetDefaults()
 	{

--- a/Content/SaltFlats/Items/Crates/SaltCrate.cs
+++ b/Content/SaltFlats/Items/Crates/SaltCrate.cs
@@ -62,7 +62,7 @@ public class SaltCrate : ModItem
 		}
 	}
 
-	public override void SetStaticDefaults() => Item.ResearchUnlockCount = 10;
+	public override void SetStaticDefaults() => Item.ResearchUnlockCount = 5;
 	public override void SetDefaults()
 	{
 		Item.DefaultToPlaceableTile(ModContent.TileType<SaltCrateTile>());

--- a/Content/SaltFlats/Items/Crates/SaltCrateHardmode.cs
+++ b/Content/SaltFlats/Items/Crates/SaltCrateHardmode.cs
@@ -15,7 +15,7 @@ public class SaltCrateHardmode : ModItem
 	public override void SetStaticDefaults()
 	{
 		ItemID.Sets.ShimmerTransformToItem[Type] = ModContent.ItemType<SaltCrate>();
-		Item.ResearchUnlockCount = 10;
+		Item.ResearchUnlockCount = 5;
 	}
 	
 	public override void SetDefaults()

--- a/Content/SaltFlats/Items/Crates/SaltCrateHardmodeRestored.cs
+++ b/Content/SaltFlats/Items/Crates/SaltCrateHardmodeRestored.cs
@@ -7,7 +7,7 @@ public class SaltCrateHardmodeRestored : ModItem
 	public override void SetStaticDefaults()
 	{
 		ItemID.Sets.ShimmerTransformToItem[Type] = ModContent.ItemType<SaltCrate>();
-		Item.ResearchUnlockCount = 10;
+		Item.ResearchUnlockCount = 5;
 	}
 	
 	public override void SetDefaults()

--- a/Content/SaltFlats/Items/Crates/SaltCrateRestored.cs
+++ b/Content/SaltFlats/Items/Crates/SaltCrateRestored.cs
@@ -22,7 +22,7 @@ public class SaltCrateRestored : ModItem
 		}
 	}
 
-	public override void SetStaticDefaults() => Item.ResearchUnlockCount = 10;
+	public override void SetStaticDefaults() => Item.ResearchUnlockCount = 5;
 	public override void SetDefaults()
 	{
 		Item.DefaultToPlaceableTile(ModContent.TileType<SaltCrateRestoredTile>());

--- a/Content/SaltFlats/NPCs/Flamingo.cs
+++ b/Content/SaltFlats/NPCs/Flamingo.cs
@@ -58,6 +58,7 @@ public class Flamingo : ModNPC
 
 	public override void SetStaticDefaults()
 	{
+		NPCID.Sets.ShimmerTransformToNPC[Type] = NPCID.Shimmerfly;
 		Main.npcFrameCount[Type] = 12; //Rows
 		NPCID.Sets.CountsAsCritter[Type] = true;
 	}

--- a/Content/SaltFlats/NPCs/Shrimp/GoldenBrineShrimp.cs
+++ b/Content/SaltFlats/NPCs/Shrimp/GoldenBrineShrimp.cs
@@ -10,7 +10,11 @@ namespace SpiritReforged.Content.SaltFlats.NPCs.Shrimp;
 public class GoldenBrineShrimp : BrineShrimp, IGoldCritter
 {
 	public override void AddRecipes() => Recipe.Create(ItemID.GoldenDelight, 1).AddIngredient(this.AutoItemType()).Register();
-	public override void CreateItemDefaults() => ItemEvents.CreateItemDefaults(this.AutoItemType(), item => item.value = Item.sellPrice(0, 5, 0, 0));
+	public override void CreateItemDefaults() => ItemEvents.CreateItemDefaults(this.AutoItemType(), item =>
+	{
+		item.value = Item.sellPrice(gold: 10);
+		item.rare = ItemRarityID.Orange;
+	});
 
 	public override void SetDefaults()
 	{

--- a/Content/SaltFlats/Tiles/Salt/SaltBlock.cs
+++ b/Content/SaltFlats/Tiles/Salt/SaltBlock.cs
@@ -1,4 +1,5 @@
 using SpiritReforged.Common;
+using SpiritReforged.Common.ItemCommon;
 using SpiritReforged.Common.TileCommon;
 using Terraria.Audio;
 
@@ -6,6 +7,7 @@ namespace SpiritReforged.Content.SaltFlats.Tiles.Salt;
 
 public abstract class SaltBlock : ModTile, IAutoloadTileItem
 {
+
 	public static readonly SoundStyle Break = new("SpiritReforged/Assets/SFX/Tile/SaltMine", 3)
 	{
 		Volume = 0.5f,

--- a/Content/Savanna/Items/Fishing/SavannaCrate.cs
+++ b/Content/Savanna/Items/Fishing/SavannaCrate.cs
@@ -7,7 +7,7 @@ namespace SpiritReforged.Content.Savanna.Items.Fishing;
 
 public class SavannaCrate : ModItem
 {
-	public override void SetStaticDefaults() => Item.ResearchUnlockCount = 10;
+	public override void SetStaticDefaults() => Item.ResearchUnlockCount = 5;
 
 	public override void SetDefaults()
 	{

--- a/Content/Savanna/Items/Fishing/SavannaCrateHardmode.cs
+++ b/Content/Savanna/Items/Fishing/SavannaCrateHardmode.cs
@@ -10,7 +10,7 @@ public class SavannaCrateHardmode : ModItem
 	public override void SetStaticDefaults()
 	{
 		ItemID.Sets.ShimmerTransformToItem[Type] = ModContent.ItemType<SavannaCrate>();
-		Item.ResearchUnlockCount = 10;
+		Item.ResearchUnlockCount = 5;
 	}
 	
 	public override void SetDefaults()

--- a/Content/Savanna/NPCs/Gar/GoldGar.cs
+++ b/Content/Savanna/NPCs/Gar/GoldGar.cs
@@ -9,7 +9,11 @@ public class GoldGar : Gar, IGoldCritter
 {
 	public int[] NormalPersistentIDs => [ModContent.NPCType<Gar>()];
 
-	public override void CreateItemDefaults() => ItemEvents.CreateItemDefaults(this.AutoItemType(), item => item.value = Item.sellPrice(gold: 10));
+	public override void CreateItemDefaults() => ItemEvents.CreateItemDefaults(this.AutoItemType(), item =>
+	{
+		item.value = Item.sellPrice(gold: 10);
+		item.rare = ItemRarityID.Orange; 
+	});
 
 	public override void OnSpawn(IEntitySource source)
 	{

--- a/Content/Savanna/NPCs/Killifish/GoldKillifish.cs
+++ b/Content/Savanna/NPCs/Killifish/GoldKillifish.cs
@@ -11,7 +11,11 @@ public class GoldKillifish : Killifish, IGoldCritter
 {
 	public int[] NormalPersistentIDs => [ModContent.NPCType<Killifish>()];
 
-	public override void CreateItemDefaults() => ItemEvents.CreateItemDefaults(this.AutoItemType(), item => item.value = Item.sellPrice(gold: 10));
+	public override void CreateItemDefaults() => ItemEvents.CreateItemDefaults(this.AutoItemType(), item =>
+	{
+		item.value = Item.sellPrice(gold: 10);
+		item.rare = ItemRarityID.Orange;
+	});
 
 	public override void OnSpawn(IEntitySource source) { }
 

--- a/Content/Underground/NPCs/DunceCrab.cs
+++ b/Content/Underground/NPCs/DunceCrab.cs
@@ -3,6 +3,7 @@ using SpiritReforged.Common.NPCCommon;
 using SpiritReforged.Common.Particle;
 using SpiritReforged.Content.Particles;
 using SpiritReforged.Content.Underground.Items.EarthshakerVanity;
+using SpiritReforged.Content.Underground.Moss;
 using SpiritReforged.Content.Vanilla.Food;
 using System.IO;
 using Terraria.Audio;
@@ -385,14 +386,16 @@ public class DunceCrab : ModNPC
 
 	public override float SpawnChance(NPCSpawnInfo spawnInfo)
 	{
+
 		if (spawnInfo.Invasion || spawnInfo.PlayerInTown)
 			return 0;
 
 		int x = spawnInfo.SpawnTileX;
 		int y = spawnInfo.SpawnTileY;
+		float mossMultiplier = ModContent.GetInstance<MossTileCounts>().neonCount >= 200 ? 1.2f : 1f;
 
 		if (y > Main.worldSurface && spawnInfo.Player.ZonePurity && !spawnInfo.Water && NPC.IsValidSpawningGroundTile(x, y))
-			return Main.hardMode ? .06f : .12f;
+			return (Main.hardMode ? .06f : .12f) * mossMultiplier;
 
 		return 0;
 	}

--- a/Content/Underground/NPCs/DunceCrab.cs
+++ b/Content/Underground/NPCs/DunceCrab.cs
@@ -386,7 +386,6 @@ public class DunceCrab : ModNPC
 
 	public override float SpawnChance(NPCSpawnInfo spawnInfo)
 	{
-
 		if (spawnInfo.Invasion || spawnInfo.PlayerInTown)
 			return 0;
 

--- a/Content/Ziggurat/NPCs/TinyGrub.cs
+++ b/Content/Ziggurat/NPCs/TinyGrub.cs
@@ -10,6 +10,7 @@ public class TinyGrub : ModNPC
 {
 	public override void SetStaticDefaults()
 	{
+		NPCID.Sets.ShimmerTransformToNPC[Type] = NPCID.Shimmerfly;
 		Main.npcFrameCount[Type] = 4;
 		NPCID.Sets.CountsAsCritter[Type] = true;
 	}

--- a/Content/Ziggurat/Tiles/TallSandstoneShelf.cs
+++ b/Content/Ziggurat/Tiles/TallSandstoneShelf.cs
@@ -15,6 +15,7 @@ public class TallSandstoneShelf : ModTile, IAutoloadTileItem
 		Main.tileSolid[Type] = true;
 		Main.tileTable[Type] = true;
 		SpiritSets.FrameHeight[Type] = 18;
+		AdjTiles = [TileID.Bookcases];
 
 		AddMapEntry(FurnitureTile.CommonColor);
 

--- a/Content/Ziggurat/Walls/PolishedSandstoneWall.cs
+++ b/Content/Ziggurat/Walls/PolishedSandstoneWall.cs
@@ -1,10 +1,21 @@
-﻿using SpiritReforged.Common.WallCommon;
+﻿using SpiritReforged.Common.ItemCommon;
+using SpiritReforged.Common.WallCommon;
+using SpiritReforged.Content.Ziggurat.Tiles;
 
 namespace SpiritReforged.Content.Ziggurat.Walls;
 
 public class PolishedSandstoneWall : ModWall, IAutoloadUnsafeWall, IAutoloadWallItem
 {
 	public static int UnsafeType { get; private set; } = SpiritReforgedMod.Instance.Find<ModWall>("PolishedSandstoneWallUnsafe").Type;
+
+	public void AddItemRecipes(ModItem item)
+	{
+		int brick = ItemID.Sandstone;
+		int type = item.Type;
+
+		item.CreateRecipe(4).AddIngredient(brick).AddTile(TileID.WorkBenches).Register();
+		Recipe.Create(brick).AddIngredient(type, 4).AddTile(TileID.WorkBenches).Register();
+	}
 
 	public override void SetStaticDefaults()
 	{

--- a/Content/Ziggurat/Walls/PolishedSandstoneWall.cs
+++ b/Content/Ziggurat/Walls/PolishedSandstoneWall.cs
@@ -1,6 +1,4 @@
-﻿using SpiritReforged.Common.ItemCommon;
-using SpiritReforged.Common.WallCommon;
-using SpiritReforged.Content.Ziggurat.Tiles;
+﻿using SpiritReforged.Common.WallCommon;
 
 namespace SpiritReforged.Content.Ziggurat.Walls;
 


### PR DESCRIPTION
- Added Crane Feather to Wood Crates
- Changed Rogue's Crest Crate odds from 12.5% to 5%
- Hardlight Visor now dropped by Grelementals at a 2% chance
- Sandstone Shelf counts as a bookshelf
- Dunce crab spawnrates increased in moss biomes
- Polished Sandstone Walls now have a crafting recipe
- Corrected Crate Research Counts
- Also increased Golden Diving Beetle sell price to 10 gold to match other golden critters
- Changed Golden Critter rarity
- Flamingo and Tiny Grub now properly shimmer into Faeling